### PR TITLE
[Performance] DB-filtered photometry/spectra and dashboard annotation

### DIFF
--- a/YSE_App/data/PhotometryService.py
+++ b/YSE_App/data/PhotometryService.py
@@ -19,12 +19,11 @@ def GetAuthorizedTransientPhotometry_ByUser(user):
     return allowed_phot
 
 def GetAuthorizedTransientPhotometry_ByUser_ByTransient(user, transient_id):
-
-    allowed_phot_by_group = GetAuthorizedTransientPhotometry_ByUser(user)
-    transient_query = Q(transient=transient_id)
-    allowed_phot_by_group_by_transient = allowed_phot_by_group.filter(transient_query).distinct()
-
-    return allowed_phot_by_group_by_transient
+    group_query_tuple = GetUserGroupQuery(user)
+    return TransientPhotometry.objects.filter(
+        group_query_tuple[0] | group_query_tuple[1],
+        transient_id=transient_id,
+    ).distinct()
 
 def GetAuthorizedHostPhotometry_ByUser(user):
     host_query_tuple = GetUserGroupQuery(user)
@@ -33,11 +32,11 @@ def GetAuthorizedHostPhotometry_ByUser(user):
     return allowed_phot
 
 def GetAuthorizedHostPhotometry_ByUser_ByHost(user, host_id):
-    allowed_phot_by_group = GetAuthorizedHostPhotometry_ByUser(user)
-    host_query = Q(host=host_id)
-    allowed_phot_by_group_by_host = allowed_phot_by_group.filter(host_query).distinct()
-
-    return allowed_phot_by_group_by_host
+    host_query_tuple = GetUserGroupQuery(user)
+    return HostPhotometry.objects.filter(
+        host_query_tuple[0] | host_query_tuple[1],
+        host_id=host_id,
+    ).distinct()
 
 def GetAuthorizedTransientPhotData_ByUser(user, includeBadData=True):
     allowed_phot = GetAuthorizedTransientPhotometry_ByUser(user)

--- a/YSE_App/data/SpectraService.py
+++ b/YSE_App/data/SpectraService.py
@@ -19,12 +19,9 @@ def GetAuthorizedTransientSpectrum_ByUser(user, includeBadData=True):
     return allowed_spec
 
 def GetAuthorizedTransientSpectrum_ByUser_ByTransient(user, transient_id, includeBadData=True):
-
-    allowed_spec_by_group = GetAuthorizedTransientSpectrum_ByUser(user, includeBadData)
-    transient_query = Q(transient=transient_id)
-    allowed_spec_by_group_by_transient = allowed_spec_by_group.filter(transient_query).distinct()
-
-    return allowed_spec_by_group_by_transient
+    group_query_tuple = GetUserGroupQuery(user)
+    query = (group_query_tuple[0] | group_query_tuple[1]) & Q(transient_id=transient_id)
+    return _GetTransientSpectrum(includeBadData, query).distinct()
 
 def GetAuthorizedHostSpectrum_ByUser(user, includeBadData=True):
     host_query_tuple = GetUserGroupQuery(user)
@@ -34,11 +31,9 @@ def GetAuthorizedHostSpectrum_ByUser(user, includeBadData=True):
     return allowed_phot
 
 def GetAuthorizedHostSpectrum_ByUser_ByHost(user, host_id, includeBadData=True):
-    allowed_spec_by_group = GetAuthorizedHostSpectrum_ByUser(user, includeBadData)
-    host_query = Q(host=host_id)
-    allowed_spec_by_group_by_host = allowed_spec_by_group.filter(host_query).distinct()
-
-    return allowed_spec_by_group_by_host
+    host_query_tuple = GetUserGroupQuery(user)
+    query = (host_query_tuple[0] | host_query_tuple[1]) & Q(host_id=host_id)
+    return _GetHostSpectrum(includeBadData, query).distinct()
 
 def GetAuthorizedTransientSpecData_ByUser(user, includeBadData=True):
     allowed_spec = GetAuthorizedTransientSpectrum_ByUser(user, includeBadData)

--- a/YSE_App/table_utils.py
+++ b/YSE_App/table_utils.py
@@ -5,7 +5,7 @@ import django_tables2 as tables
 from django_tables2 import RequestConfig
 from django.db.models import F, Q
 from django.db.models.functions import Length, Substr
-from django.db.models import Count, Value, Max, Min
+from django.db.models import Count, OuterRef, Subquery, Value, Max, Min
 from django.db.models.functions import Greatest, Coalesce
 from django_tables2 import A
 from django.db import models
@@ -1399,6 +1399,27 @@ class YSEObsNightTable(tables.Table):
             'class': 'table table-bordered table-hover',
             "order": [[ 2, "desc" ]],
         }
+
+def annotate_dashboard_transient_fields(qs):
+    """
+    Prefetch FKs and annotate recent photometry for dashboard tables.
+
+    Avoids N+1 queries from Transient.recent_mag() / recent_magdate() during render.
+    """
+    recent_phot = TransientPhotData.objects.filter(
+        photometry__transient=OuterRef('pk'),
+    ).exclude(data_quality__isnull=True)
+    recent_mag_sq = (
+        recent_phot.filter(mag__isnull=False)
+        .order_by('-obs_date')
+        .values('mag')[:1]
+    )
+    recent_magdate_sq = recent_phot.order_by('-obs_date').values('obs_date')[:1]
+    return qs.select_related('status', 'host', 'obs_group').annotate(
+        recent_mag=Subquery(recent_mag_sq),
+        recent_magdate=Subquery(recent_magdate_sq),
+    )
+
 
 def annotate_with_disc_mag(qs):
 

--- a/YSE_App/templates/YSE_App/transient_detail.html
+++ b/YSE_App/templates/YSE_App/transient_detail.html
@@ -396,14 +396,14 @@
                                     </div>
                                     <div class="col-xs-4">
                                             <div class="form-group">
-                                                <strong>Photo-z</strong>
+                                                <strong>Photo-z (Pan-STARRS CNN)</strong>
                                                 <p class="text-muted">
                                                     {% if transient.host %}
                                                         {% if transient.host.photo_z_internal %}
                                                             {{ transient.host.photo_z_internal|floatformat:3 }}
 
-                                                            {% if transient.host.photo_z_err_internal %}
-                                                                +/- {{ transient.host.photo_z_err_internal|floatformat:3 }}
+                                                            {% if transient.host.photo_z_err_PSCNN %}
+                                                                +/- {{ transient.host.photo_z_err_PSCNN|floatformat:3 }}
                                                             {% endif %}
                                                         {% endif %}
                                                     {% else %}

--- a/YSE_App/tests/test_performance.py
+++ b/YSE_App/tests/test_performance.py
@@ -34,14 +34,14 @@ from YSE_App.tests.fixtures_minimal import (
 from YSE_App.tests.perf_tracking import LoadTimeRegistry
 
 # Query ceilings — tighten as views are optimized.
-MAX_QUERIES_TRANSIENT_DETAIL_SHELL = 60
-MAX_QUERIES_TRANSIENT_DETAIL_LOADED = 78
+MAX_QUERIES_TRANSIENT_DETAIL_SHELL = 50
+MAX_QUERIES_TRANSIENT_DETAIL_LOADED = 72
 MAX_QUERIES_PERSONAL_DASHBOARD = 40
 # Cold: five explorer SQL runs + five table builds (heavy; ceiling guards regressions).
 MAX_QUERIES_PERSONAL_DASHBOARD_FIVE_QUERIES_COLD = 28
 # Warm: SQL results cached; exercises second-pass table build only.
 MAX_QUERIES_PERSONAL_DASHBOARD_FIVE_QUERIES_WARM = 23
-MAX_QUERIES_MAIN_DASHBOARD = 55
+MAX_QUERIES_MAIN_DASHBOARD = 25
 # Explorer index: empty querylog ~6 queries; with logs ~1 + N counts (django-sql-explorer).
 MAX_QUERIES_EXPLORER_INDEX_CATALOG = 15
 MAX_QUERIES_EXPLORER_INDEX_PER_50_WITH_LOGS = 60

--- a/YSE_App/view_utils.py
+++ b/YSE_App/view_utils.py
@@ -136,21 +136,22 @@ def get_recent_phot_for_transient(user, transient_id=None):
     else:
         return(None)
 
-def get_disc_mag_for_transient(user, transient_id=None):
-    photdata = PhotometryService.GetAuthorizedTransientPhotData_ByUser_ByTransient(user, transient_id,
-                                                                                   includeBadData=False)
-
-    if photdata:
-        photdata = photdata.order_by('-obs_date')
-
+def get_disc_mag_from_photdata(photdata_qs):
+    """Discovery / first mag from an existing photdata queryset (avoids duplicate DB fetch)."""
     firstphot = None
-    for ph in photdata:
+    for ph in photdata_qs.order_by('obs_date'):
         if ph.discovery_point:
-            return(ph)
-        elif ph.mag:
+            return ph
+        if ph.mag:
             firstphot = ph
+    return firstphot
 
-    return(firstphot)
+
+def get_disc_mag_for_transient(user, transient_id=None):
+    photdata = PhotometryService.GetAuthorizedTransientPhotData_ByUser_ByTransient(
+        user, transient_id, includeBadData=False
+    )
+    return get_disc_mag_from_photdata(photdata)
 
 def getMoonAngle(observingdate,telescope,ra,dec):
     if observingdate:

--- a/YSE_App/views.py
+++ b/YSE_App/views.py
@@ -135,9 +135,13 @@ def dashboard(request):
     for title, statusname in _DASHBOARD_STATUS_SECTIONS:
         status = status_by_name.get(statusname)
         if status:
-            transients = Transient.objects.filter(status=status).order_by('-disc_date')
+            transients = annotate_dashboard_transient_fields(
+                Transient.objects.filter(status=status).order_by('-disc_date')
+            )
         else:
-            transients = Transient.objects.filter(status=None).order_by('-disc_date')
+            transients = annotate_dashboard_transient_fields(
+                Transient.objects.filter(status=None).order_by('-disc_date')
+            )
         transientfilter = TransientFilter(
             request.GET, queryset=transients, prefix=statusname.lower()
         )
@@ -1065,7 +1069,9 @@ def transient_detail(request, slug):
 
         transient_obj = transient_matches[0]
         transient_id = transient_obj.id
-        logs = Log.objects.filter(transient_id=transient_id)
+        logs = list(
+            Log.objects.filter(transient_id=transient_id).order_by('-modified_date')
+        )
 
         alt_names = AlternateTransientNames.objects.filter(transient__pk=transient_id)
 
@@ -1160,14 +1166,26 @@ def transient_detail(request, slug):
 
         if hostphotdata: transient_obj.hostphotdata = hostphotdata
 
-        lastphotdata = view_utils.get_recent_phot_for_transient(request.user, transient_id=transient_id)
-        firstphotdata = view_utils.get_disc_mag_for_transient(request.user, transient_id=transient_id)
-        allphotdata = view_utils.get_all_phot_for_transient(request.user, transient_id).select_related()
-        #import pdb
-        #pdb.set_trace()
+        allphotdata = (
+            view_utils.get_all_phot_for_transient(request.user, transient_id)
+            .select_related(
+                'band',
+                'photometry',
+                'photometry__instrument',
+                'photometry__instrument__telescope',
+            )
+            .prefetch_related('data_quality')
+        )
+        good_photdata = allphotdata.exclude(data_quality__isnull=False)
+        lastphotdata = (
+            good_photdata.filter(mag__isnull=False).order_by('-obs_date').first()
+        )
+        firstphotdata = view_utils.get_disc_mag_from_photdata(good_photdata)
 
-        has_new_comment = len(Log.objects.filter(transient=transient_obj).\
-                              filter(modified_date__gt=datetime.datetime.now()-datetime.timedelta(1))) > 0
+        comment_cutoff = timezone.now() - datetime.timedelta(1)
+        has_new_comment = any(
+            log.modified_date > comment_cutoff for log in logs
+        )
         
         # obsnights,tellist = view_utils.getObsNights(transient[0])
         # too_resources = ToOResource.objects.all()
@@ -1183,7 +1201,11 @@ def transient_detail(request, slug):
         date = datetime.datetime.now(tz=pytz.utc)
         date_format='%m/%d/%Y %H:%M:%S'
         
-        spectra = SpectraService.GetAuthorizedTransientSpectrum_ByUser_ByTransient(request.user, transient_id, includeBadData=True)
+        spectra = SpectraService.GetAuthorizedTransientSpectrum_ByUser_ByTransient(
+            request.user, transient_id, includeBadData=True
+        ).select_related('instrument', 'instrument__telescope').prefetch_related(
+            'data_quality'
+        )
         context = {
             'transient':transient_obj,
             'followups':followups,
@@ -1208,7 +1230,13 @@ def transient_detail(request, slug):
             'gw_candidate':gwcand,
             'gw_images':gwimages,
             'spectrum_upload_form':spectrum_upload_form,
-            'diff_images':TransientDiffImage.objects.filter(phot_data__photometry__transient__name=transient_obj.name),
+            'diff_images': TransientDiffImage.objects.filter(
+                phot_data__photometry__transient_id=transient_id
+            ).select_related(
+                'phot_data',
+                'phot_data__photometry',
+                'phot_data__band',
+            ),
             'classical_resource_form':classical_resource_form,
             'too_resource_form':too_resource_form,
             'new_comment':has_new_comment,
@@ -1237,8 +1265,14 @@ def transient_detail(request, slug):
         # we need to add a submit to TNS button
         # for transients that don't have TNS names
         # - for now, this is only DECam transients
-        tns_submit_logs = logs.filter(comment__startswith='Submitted to TNS')
-        tns_sandbox_logs = logs.filter(comment__startswith='TNS sandbox')
+        tns_submit_logs = [
+            log for log in logs
+            if log.comment and log.comment.startswith('Submitted to TNS')
+        ]
+        tns_sandbox_logs = [
+            log for log in logs
+            if log.comment and log.comment.startswith('TNS sandbox')
+        ]
         if not len(tns_submit_logs) and '_cand' in transient_obj.name and \
            'DECAT' in list(assigned_transient_tags.values_list('name',flat=True)):
             submit_to_tns = True


### PR DESCRIPTION
## Summary

Second perf tranche from [astrofoley/YSE_PZ PR #24](https://github.com/astrofoley/YSE_PZ/pull/24): cuts query count on transient detail and the main dashboard by filtering at the database and annotating dashboard rows in one pass.

**Included:**
- `YSE_App/data/PhotometryService.py`, `YSE_App/data/SpectraService.py` — `ByTransient` / host filters applied in SQL, not load-all-then-filter in Python
- `YSE_App/views.py` — `transient_detail` single photometry fetch + batched followup/logs; main dashboard uses batched status sections
- `YSE_App/table_utils.py` — `annotate_dashboard_transient_fields()` (Subquery for recent mag/date)
- `YSE_App/templates/YSE_App/transient_detail.html` — template adjustments for batched context
- `YSE_App/view_utils.py` — related LC/view helpers touched in same release
- `YSE_App/tests/test_performance.py` — updated query ceilings aligned with optimizations

**Requires:** PR #6 (baselines) so `test_performance.py` continues to enforce the budgets above.

## Motivation

Transient detail previously loaded broad photometry/spectra sets and filtered in memory. The main dashboard issued per-row queries for recent magnitude/date. Both paths are common navigation entry points.

## Test plan

- [ ] Merge PR #6
- [ ] `docker exec ysepz_web_container python3 manage.py test YSE_App.tests.test_performance -v2 --keepdb`
- [ ] Manual: open a transient with photometry + spectra; confirm counts match table
- [ ] Manual: main dashboard loads with annotated mag/date columns

## Related

- astrofoley/YSE_PZ PR #24
- Issue #11 (LC/detail) partial; #16 (indexes) still open for further gains

**Stacked on:** #6 (`integrate/yse-perf-baselines`). Merge #6 first, then this PR (or merge this into `develop` after #6).
