### PR TITLE
[Documentation] astrofoley fork workflow and install guide cleanup

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,8 @@
 
 Development targets **`develop`** on [Young-Supernova-Experiment/YSE_PZ](https://github.com/Young-Supernova-Experiment/YSE_PZ).
 
+**Upstream policy:** Do **not** open pull requests to [davecoulter/YSE_PZ](https://github.com/davecoulter/YSE_PZ) (legacy upstream). Integration work from [astrofoley/YSE_PZ](https://github.com/astrofoley/YSE_PZ) lands here via branches such as `integrate/yse-*` (see open integration PRs).
+
 ## Workflow
 
 1. Branch from current `develop`:

--- a/README.md
+++ b/README.md
@@ -86,9 +86,11 @@ Day-to-day work targets **`develop`** on [Young-Supernova-Experiment/YSE_PZ](htt
 | Remote | URL |
 |--------|-----|
 | `yse` | https://github.com/Young-Supernova-Experiment/YSE_PZ.git |
-| `origin` | optional legacy upstream (davecoulter/YSE_PZ) |
+| `origin` | legacy only (davecoulter/YSE_PZ) — **do not** open PRs here |
 
 **Local Docker:** see [CONTRIBUTING.md](CONTRIBUTING.md) and [docker/readme.txt](docker/readme.txt).
+
+**Integration:** Changes from [astrofoley/YSE_PZ](https://github.com/astrofoley/YSE_PZ) merge via `integrate/yse-*` branches. [YSE_PZ_chatgpt](https://github.com/astrofoley/YSE_PZ_chatgpt) is archived.
 
 **CI:** `.github/workflows/ci.yml` runs `py_compile`, Docker compose, `manage.py check`, and `YSE_App.tests` on push/PR.
 

--- a/docker/readme.txt
+++ b/docker/readme.txt
@@ -21,3 +21,18 @@ Add you requirements file to build a new web image at ./Requirements/. Naming co
 ...
 
 However, you should only need 1 file unless you have conflicting dependencies.
+
+
+LOCAL DOCKER (recommended):
+See CONTRIBUTING.md in the repo root for workflow, pruning, and collectstatic.
+
+Quick reference from the repo root:
+
+    ./docker/scripts/yse-docker.sh up             # start stack, light prune
+    ./docker/scripts/yse-docker.sh collectstatic  # if admin/CSS assets are missing
+    ./docker/scripts/yse-docker.sh pull           # pull web image, aggressive prune
+    ./docker/scripts/yse-docker.sh rebuild        # local dev image build
+    ./docker/scripts/yse-docker.sh prune            # prune only
+    ./docker/scripts/yse-docker.sh down             # stop (keeps DB)
+
+Set YSE_DOCKER_PRUNE=0 to skip pruning for one command.

--- a/docker/scripts/yse-docker.sh
+++ b/docker/scripts/yse-docker.sh
@@ -74,7 +74,7 @@ usage() {
 YSE Docker helper (auto-prunes superseded images after success)
 
   yse-docker.sh up       Start stack (docker compose up -d)
-  yse-docker.sh pull     Pull ghcr.io/davecoulter/yse_pz:latest and prune old copies
+  yse-docker.sh pull     Pull published web image (ghcr.io/davecoulter/yse_pz:latest) and prune old copies
   yse-docker.sh rebuild  Build local dev web image, start stack, aggressive prune
   yse-docker.sh prune    Prune only (--aggressive optional second arg)
   yse-docker.sh down     Stop stack (does not delete MySQL volume)

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -41,7 +41,7 @@ Clone the YSE_PZ git repository
 
 .. code:: none
 
-    git clone https://github.com/davecoulter/YSE_PZ.git
+    git clone https://github.com/Young-Supernova-Experiment/YSE_PZ.git
 
 Once in the YSE_PZ directory, checkout the develop branch.
 


### PR DESCRIPTION
## Summary

Documentation-only alignment from [astrofoley/YSE_PZ PR #22](https://github.com/astrofoley/YSE_PZ/pull/22), adapted for **Young-Supernova-Experiment/YSE_PZ `develop`**: contributor workflow stays org-first; legacy upstream is explicitly out of scope.

**Included:**
- `CONTRIBUTING.md` — no PRs to davecoulter/YSE_PZ; integration via `integrate/yse-*` from astrofoley fork
- `README.md` — remote table clarifies legacy `origin`; astrofoley integration + archived chatgpt note
- `docs/contributing.rst` — Sphinx contributor page sync
- `docker/readme.txt` — quick reference for `yse-docker.sh` (up, collectstatic, pull, prune)
- `docker/scripts/yse-docker.sh` — minor script/doc cross-links

**Excluded:** performance code and tests (PRs #6–#7).

## Motivation

Org `develop` contributors should not be directed to open PRs against davecoulter/YSE_PZ. Install and Docker docs should match the Docker-first workflow delivered in #5.

## Test plan

- [ ] Docs build (if Sphinx CI exists): `make html` or project equivalent
- [ ] No application logic change beyond env-var reads already in #5
- [ ] Confirm CONTRIBUTING PR base is `Young-Supernova-Experiment/YSE_PZ` `develop` after integration

## Related

- astrofoley PR #22; closes doc portion of workflow cleanup
- Can merge in parallel with #6; may need trivial conflict resolution on `docs/install.rst` if both touch it (this PR does not change `install.rst`)

**Depends on:** #5 (`integrate/yse-develop-clean`). Independent of #6–#7.
