### PR TITLE
[Tests] LC flux/summary query baselines; Photo_Z bulk_update and plot fixes

### DIFF
--- a/YSE_App/data_ingest/Photo_Z.py
+++ b/YSE_App/data_ingest/Photo_Z.py
@@ -1,4 +1,5 @@
 from django_cron import CronJobBase, Schedule
+from YSE_App.models.host_models import Host
 from YSE_App.models.transient_models import *
 from YSE_App.common.alert import sendemail
 from django.conf import settings as djangoSettings
@@ -224,13 +225,17 @@ class YSE(CronJobBase):
                 
             #now I have an ordered list of whats_left, which are indices that can be used to match to hosts, and an ordered list of posteriors, 
             #uncertainties, and their point estimates. place them into the model by looping over.
-            for i,value in enumerate(whats_left):
+            hosts_to_update = []
+            for i, value in enumerate(whats_left):
                 T = transient_dictionary[value]
                 T.host.photo_z_internal = point_estimates[i]
                 T.host.photo_z_err_internal = error[i]
-                #T.host.photo_z_posterior = posterior[i] #Gautham suggested we add it to the host model
-                #T.host.photo_z_source = 'YSE internal'
-                T.host.save() #takes a long time and then my query needs to be reset which is also a long time
+                hosts_to_update.append(T.host)
+            if hosts_to_update:
+                Host.objects.bulk_update(
+                    hosts_to_update,
+                    ['photo_z_internal', 'photo_z_err_internal'],
+                )
             
             print('time taken with upload:', datetime.datetime.utcnow() - nowdate)
             

--- a/YSE_App/tests/test_lightcurve.py
+++ b/YSE_App/tests/test_lightcurve.py
@@ -101,16 +101,44 @@ class LightcurvePlotTests(TestCase):
         self.assertGreater(len(response.content), 100)
         self.assertIn(b"plot", response.content.lower())
 
-    def test_lightcurveplot_detail_query_count_bounded(self):
-        """Regression: avoid per-point PhotometricBand.objects.get N+1 queries."""
+    def _assert_query_count_bounded(self, url, max_queries, label):
         from django.db import connection
         from django.test.utils import CaptureQueriesContext
 
         with CaptureQueriesContext(connection) as context:
-            response = self.client.get(f"/lightcurveplot_detail/{self.transient.id}/")
-        self.assertEqual(response.status_code, 200)
+            response = self.client.get(url)
+        self.assertEqual(response.status_code, 200, msg=label)
         self.assertLess(
             len(context.captured_queries),
-            25,
-            msg="too many queries for single-point LC plot",
+            max_queries,
+            msg=f"{label}: {len(context.captured_queries)} queries (max {max_queries})",
         )
+
+    def test_lightcurveplot_detail_query_count_bounded(self):
+        """Regression: avoid per-point PhotometricBand.objects.get N+1 queries."""
+        self._assert_query_count_bounded(
+            f"/lightcurveplot_detail/{self.transient.id}/",
+            max_queries=25,
+            label="lightcurveplot_detail",
+        )
+
+    def test_lightcurveplot_flux_query_count_bounded(self):
+        self._assert_query_count_bounded(
+            f"/lightcurveplot_flux/{self.transient.id}/",
+            max_queries=25,
+            label="lightcurveplot_flux",
+        )
+
+    def test_lightcurveplot_summary_query_count_bounded(self):
+        self._assert_query_count_bounded(
+            f"/lightcurveplot_summary/{self.transient.id}/",
+            max_queries=25,
+            label="lightcurveplot_summary",
+        )
+
+    def test_lightcurveplot_flux_empty_returns_empty_body(self):
+        response = self.client.get(
+            f"/lightcurveplot_flux/{self.transient_empty.id}/"
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.content, b"")

--- a/YSE_App/tests/test_performance.py
+++ b/YSE_App/tests/test_performance.py
@@ -58,6 +58,8 @@ MAX_SECONDS_TRANSIENT_DETAIL_SHELL = 8.0
 MAX_SECONDS_TRANSIENT_DETAIL_LOADED = 12.0
 MAX_SECONDS_PERSONAL_DASHBOARD = 3.0
 MAX_SECONDS_MAIN_DASHBOARD = 6.0
+MAX_QUERIES_CALENDAR = 12
+MAX_SECONDS_CALENDAR = 3.0
 
 SKIP_TIMING = os.environ.get("YSE_PERF_SKIP_TIMING", "").lower() in ("1", "true", "yes")
 
@@ -371,3 +373,30 @@ class MainDashboardPerformanceTests(TestCase):
         response, n_queries, elapsed = _profile_get(self.client, url)
         self.assertEqual(response.status_code, 200)
         self.assertLess(n_queries, MAX_QUERIES_MAIN_DASHBOARD)
+
+
+@override_settings(PASSWORD_HASHERS=["django.contrib.auth.hashers.MD5PasswordHasher"])
+class CalendarPerformanceTests(TestCase):
+    """On-call calendar: /calendar/"""
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.user = create_test_user("perf_calendar_user")
+
+    def setUp(self):
+        self.client = Client()
+        self.client.force_login(self.user)
+
+    def test_calendar_returns_200(self):
+        url = "/calendar/"
+        response, n_queries, elapsed = _profile_get(self.client, url)
+        assert_page_load(
+            self,
+            page="calendar",
+            url=url,
+            response=response,
+            n_queries=n_queries,
+            elapsed=elapsed,
+            max_queries=MAX_QUERIES_CALENDAR,
+            max_seconds=MAX_SECONDS_CALENDAR,
+        )

--- a/YSE_App/view_utils.py
+++ b/YSE_App/view_utils.py
@@ -612,7 +612,7 @@ def lightcurveplot_summary(request, transient_id, salt2=False):
 
     # Convert observation dates to MJD
     mjd = date_to_mjd(obs_date)
-    obs_date_str = [date.strftime("%m/%d/%Y") for date in obs_date]
+    obs_date_str = [p["obs_date"].strftime("%m/%d/%Y") for p in phot_values]
 
     # Initialize plot
     colorlist = ['#8dd3c7', '#bebada', '#fb8072', '#80b1d3', '#fdb462', '#b3de69', '#fccde5', '#d9d9d9']
@@ -708,7 +708,14 @@ def lightcurveplot_summary(request, transient_id, salt2=False):
         limmjd = None
         mjd_range = (mjd.min() - 10, mjd.max() + 10)
     ax.x_range = Range1d(*mjd_range)
-    ax.y_range = Range1d(np.max(upperlimmag) + 0.25, np.min(mag) - 0.5)
+    if len(upperlimmag):
+        y_hi = float(np.max(upperlimmag)) + 0.25
+    elif len(mag):
+        y_hi = float(np.max(mag)) + 0.5
+    else:
+        y_hi = 20.0
+    y_lo = float(np.min(mag)) - 0.5 if len(mag) else y_hi - 2.0
+    ax.y_range = Range1d(y_hi, y_lo)
 
     majorticks = []
     overridedict = {}
@@ -1092,9 +1099,14 @@ def lightcurveplot_flux(request, transient_id, salt2=False):
     tstart = time.time()
 
     transient = Transient.objects.get(pk=transient_id)
-    photdata = get_all_phot_for_transient(request.user, transient_id).all().select_related(
-        'created_by', 'modified_by', 'band', 'unit', 'photometry',
-        'band__instrument','band__instrument__telescope')
+    photdata = (
+        get_all_phot_for_transient(request.user, transient_id)
+        .select_related(
+            'created_by', 'modified_by', 'band', 'unit', 'photometry',
+            'band__instrument', 'band__instrument__telescope', 'mag_sys',
+        )
+        .prefetch_related('data_quality')
+    )
     if not photdata:
         return django.http.HttpResponse('')
 
@@ -1123,11 +1135,13 @@ def lightcurveplot_flux(request, transient_id, salt2=False):
             if p.mag_sys is None: magsys = np.append(magsys,['None'])
             else: magsys = np.append(magsys,[p.mag_sys])
 
-            dqs = p.data_quality.all()
-            if not len(dqs):
-                data_quality = np.append(data_quality,['Good'])
+            dqs = list(p.data_quality.all())
+            if not dqs:
+                data_quality = np.append(data_quality, ['Good'])
             else:
-                data_quality = np.append(data_quality,[','.join(np.array([pdq.name for pdq in p.data_quality.all()]))])
+                data_quality = np.append(
+                    data_quality, [','.join(pdq.name for pdq in dqs)]
+                )
 
             if not p.flux or not p.flux_err:
                 flux_single = 10**(-0.4*(p.mag-27.5))


### PR DESCRIPTION
## Summary

Third application tranche from astrofoley **[PR #25](https://github.com/astrofoley/YSE_PZ/pull/25)** (`fix/f-query-baselines`, merged on astrofoley `main`):

**Included:**
- `YSE_App/tests/test_lightcurve.py` — `assertNumQueries` helpers for flux and summary lightcurve endpoints
- `YSE_App/tests/test_performance.py` — calendar-related perf test additions
- `YSE_App/data_ingest/Photo_Z.py` — `bulk_update` instead of per-row saves where applicable
- `YSE_App/view_utils.py` — summary plot date handling (`numpy.datetime64`), empty upper-limit y-range guard, `prefetch_related('data_quality')` on flux queries

**Depends on:** PR #7 (`integrate/yse-perf-queries`). Merge #5 → #6 → #7 first (or merge this after #7 into `develop`).

## Motivation

LC endpoints had no query regression coverage; summary plot failed on edge-case dates and empty upper limits. Photo_Z ingest was chatty on the DB.

## Test plan

- [ ] Merge PRs #6 and #7 (or confirm branch includes their commits)
- [ ] `docker exec ysepz_web_container python3 manage.py test YSE_App.tests.test_lightcurve YSE_App.tests.test_performance -v2 --keepdb`
- [ ] Hit lightcurve flux + summary URLs for one test transient

## Related

- astrofoley PR #25
- astrofoley issues #11 (LC), #15 (calendar partial)

**Stacked on:** #7 (`integrate/yse-perf-queries`).
