### PR TITLE
Fix dashboard annotations, host photometry, and query cache

### DIFF
--- a/YSE_App/table_utils.py
+++ b/YSE_App/table_utils.py
@@ -1406,9 +1406,10 @@ def annotate_dashboard_transient_fields(qs):
 
     Avoids N+1 queries from Transient.recent_mag() / recent_magdate() during render.
     """
+    # Match PhotometryService / Transient.recent_mag: exclude flagged bad data.
     recent_phot = TransientPhotData.objects.filter(
         photometry__transient=OuterRef('pk'),
-    ).exclude(data_quality__isnull=True)
+    ).exclude(data_quality__isnull=False)
     recent_mag_sq = (
         recent_phot.filter(mag__isnull=False)
         .order_by('-obs_date')

--- a/YSE_App/tests/test_post_merge_hotfix.py
+++ b/YSE_App/tests/test_post_merge_hotfix.py
@@ -1,0 +1,80 @@
+"""Regression tests for post-merge dashboard / host photometry fixes."""
+
+from django.test import TestCase
+from django.utils import timezone
+
+from YSE_App.data import SpectraService
+from YSE_App.models import Host, HostPhotData, HostPhotometry, Transient
+from YSE_App.table_utils import annotate_dashboard_transient_fields
+from YSE_App.tests.fixtures_minimal import (
+    attach_synthetic_photometry,
+    audit_fields,
+    create_instrument_stack,
+    create_test_user,
+    create_minimal_transient,
+    create_transient_with_synthetic_data,
+)
+from YSE_App import view_utils
+
+
+class AnnotateDashboardFieldsTests(TestCase):
+    def test_recent_mag_and_date_populated_when_photometry_exists(self):
+        user = create_test_user(username="annotate_dashboard_user")
+        transient = create_minimal_transient(user, name="annotate-mag-test")
+        attach_synthetic_photometry(user, transient, n_points=3)
+
+        row = annotate_dashboard_transient_fields(
+            Transient.objects.filter(pk=transient.pk)
+        ).first()
+
+        self.assertIsNotNone(row.recent_mag)
+        self.assertIsNotNone(row.recent_magdate)
+
+
+class HostPhotDataHelperTests(TestCase):
+    def test_get_recent_phot_for_host_returns_model_or_none(self):
+        user = create_test_user(username="host_phot_user")
+        audit = audit_fields(user)
+        obs_group, instrument, band = create_instrument_stack(
+            user, obs_group_name="host-phot-stack"
+        )
+        host = Host.objects.create(
+            name="host-phot-test",
+            ra=10.0,
+            dec=20.0,
+            **audit,
+        )
+        photometry = HostPhotometry.objects.create(
+            host=host,
+            instrument=instrument,
+            obs_group=obs_group,
+            **audit,
+        )
+        HostPhotData.objects.create(
+            photometry=photometry,
+            band=band,
+            mag=18.5,
+            obs_date=timezone.now(),
+            **audit,
+        )
+
+        result = view_utils.get_recent_phot_for_host(user, host_id=host.id)
+        self.assertIsInstance(result, HostPhotData)
+        self.assertEqual(result.mag, 18.5)
+
+        empty = view_utils.get_recent_phot_for_host(user, host_id=999999)
+        self.assertIsNone(empty)
+
+
+class SpectraAuthorizationTests(TestCase):
+    """2026kie-style empty UI is usually missing DB rows or group-restricted spectra."""
+
+    def test_groupless_synthetic_spectrum_is_authorized(self):
+        user = create_test_user(username="spectra_auth_user")
+        transient = create_transient_with_synthetic_data(
+            user, name="spec-auth-test", with_spectrum=True
+        )
+        spectra = SpectraService.GetAuthorizedTransientSpectrum_ByUser_ByTransient(
+            user, transient.id, includeBadData=True
+        )
+        self.assertEqual(spectra.count(), 1)

--- a/YSE_App/view_utils.py
+++ b/YSE_App/view_utils.py
@@ -161,11 +161,7 @@ def get_recent_phot_for_host(user, host_id=None):
     allowed_phot = PhotometryService.GetAuthorizedHostPhotometry_ByUser_ByHost(user, host_id)
 
     photdata = HostPhotData.objects.filter(photometry__in=allowed_phot).order_by('-obs_date').first()
-    
-    if photdata:
-        return(photdata[0])
-    else:
-        return(None)
+    return photdata
 
 def get_all_phot_for_transient(user, transient_id=None):
     photdata = PhotometryService.GetAuthorizedTransientPhotData_ByUser_ByTransient(

--- a/YSE_App/views.py
+++ b/YSE_App/views.py
@@ -21,8 +21,13 @@ import zipfile
 from io import BytesIO
 from YSE_App.yse_utils.yse_pa import yse_pa
 from django.utils.decorators import method_decorator
+import logging
+import os
 
 from astropy.utils import iers
+
+logger = logging.getLogger(__name__)
+QUERY_CACHE_VERSION = os.environ.get('YSE_QUERY_CACHE_VERSION', '2')
 iers.conf.auto_download = True
 from astropy.utils.iers import conf
 conf.auto_max_age = None
@@ -182,10 +187,10 @@ def personaldashboard(request):
                 if 'yse_app_transient' not in sql or 'name' not in sql or not sql.startswith('select'):
                     continue
 
-                cache_key = f'user_query_{q.id}'
+                cache_key = f'user_query_{QUERY_CACHE_VERSION}_{q.id}'
                 cached_result = cache.get(cache_key)
 
-                if not cached_result:
+                if cached_result is None:
                     cursor = connections['explorer'].cursor()
                     cursor.execute(q.query.sql.replace('%', '%%'), ())
                     cached_result = [row[0] for row in cursor.fetchall()]
@@ -196,6 +201,7 @@ def personaldashboard(request):
                 sql_dashboard_sections.append((q, cached_result))
 
             except Exception as e:
+                cache.delete(f'user_query_{QUERY_CACHE_VERSION}_{q.id}')
                 logger.error(f"Error processing query {q.id}: {e}")
                 tables.append(
                     (


### PR DESCRIPTION
## Summary

- Fix `annotate_dashboard_transient_fields` to use `exclude(data_quality__isnull=False)` so main/personal dashboard **Last Mag** and **Last Obs Date** match `PhotometryService` and `Transient.recent_mag()`.
- Fix `get_recent_phot_for_host` to return the `.first()` `HostPhotData` instance (fixes `transient_detail/2019np` subscript error).
- Harden `personaldashboard` SQL cache: versioned cache keys, treat only `None` as miss, delete cache entry on SQL errors (does not revert Tier A Redis/LocMem).
- Add `YSE_App.tests.test_post_merge_hotfix` for annotate, host phot, and spectra authorization with groupless synthetic data.

## 2026kie spectra

Not caused by photo-z template revert (`5d0909b4`). `transient_detail` uses `SpectraService` with `includeBadData=True`. Empty UI is usually **no `TransientSpectrum` rows** or spectra restricted to Django groups the login user lacks. Regression test confirms groupless synthetic spectra are authorized.

## Test plan

- [ ] CI: `manage.py test YSE_App.tests` (Docker workflow)
- [ ] `/dashboard/` — Last Mag / Last Obs for transients with photometry
- [ ] `/personaldashboard/` — saved SQL sections load or show `[QUERY FAILED]` without poisoning cache (`YSE_QUERY_CACHE_VERSION=2` or `YSE_CLEAR_QUERY_CACHE=1` if needed)
- [ ] `/transient_detail/2019np/` — no HostPhotData error (needs host transient in DB)
- [ ] `/transient_detail/2026kie/` — spectra if present in DB and user has group access

Closes post-merge issues reported after org PRs #5–#12. Does not revert Tier A caching.


Made with [Cursor](https://cursor.com)