### PR TITLE
Fix spectrumplot 500 on empty and mixed spectrum data

### DIFF
--- a/YSE_App/tests/test_post_merge_hotfix.py
+++ b/YSE_App/tests/test_post_merge_hotfix.py
@@ -1,10 +1,17 @@
 """Regression tests for post-merge dashboard / host photometry fixes."""
 
-from django.test import TestCase
+from django.test import Client, TestCase
 from django.utils import timezone
 
 from YSE_App.data import SpectraService
-from YSE_App.models import Host, HostPhotData, HostPhotometry, Transient
+from YSE_App.models import (
+    Host,
+    HostPhotData,
+    HostPhotometry,
+    Transient,
+    TransientSpecData,
+    TransientSpectrum,
+)
 from YSE_App.table_utils import annotate_dashboard_transient_fields
 from YSE_App.tests.fixtures_minimal import (
     attach_synthetic_photometry,
@@ -78,3 +85,51 @@ class SpectraAuthorizationTests(TestCase):
             user, transient.id, includeBadData=True
         )
         self.assertEqual(spectra.count(), 1)
+
+
+class SpectrumPlotRegressionTests(TestCase):
+    def setUp(self):
+        self.user = create_test_user(username="spectrumplot_regression_user")
+        self.client = Client()
+        self.client.force_login(self.user)
+
+    def _add_spec_points(self, spectrum, n_points=20):
+        for i in range(n_points):
+            TransientSpecData.objects.create(
+                spectrum=spectrum,
+                wavelength=4000 + 10 * i,
+                flux=1.0 + 0.1 * i,
+            )
+
+    def test_spectrumplot_returns_200_with_valid_points(self):
+        transient = create_transient_with_synthetic_data(
+            self.user, name="specplot-valid", with_spectrum=True
+        )
+        spectrum = TransientSpectrum.objects.filter(transient=transient).first()
+        self._add_spec_points(spectrum)
+
+        response = self.client.get(f"/spectrumplot/{transient.id}/")
+        self.assertEqual(response.status_code, 200)
+
+    def test_spectrumplot_skips_empty_spectrum_and_still_returns_200(self):
+        transient = create_transient_with_synthetic_data(
+            self.user, name="specplot-empty-guard", with_spectrum=True
+        )
+        empty_spectrum = TransientSpectrum.objects.filter(transient=transient).first()
+        self.assertIsNotNone(empty_spectrum)
+
+        nonempty_spectrum = TransientSpectrum.objects.create(
+            transient=transient,
+            instrument=empty_spectrum.instrument,
+            obs_group=empty_spectrum.obs_group,
+            ra=transient.ra,
+            dec=transient.dec,
+            obs_date=timezone.now(),
+            redshift=0.05,
+            created_by=self.user,
+            modified_by=self.user,
+        )
+        self._add_spec_points(nonempty_spectrum)
+
+        response = self.client.get(f"/spectrumplot/{transient.id}/")
+        self.assertEqual(response.status_code, 200)

--- a/YSE_App/tests/test_post_merge_hotfix.py
+++ b/YSE_App/tests/test_post_merge_hotfix.py
@@ -99,6 +99,8 @@ class SpectrumPlotRegressionTests(TestCase):
                 spectrum=spectrum,
                 wavelength=4000 + 10 * i,
                 flux=1.0 + 0.1 * i,
+                created_by=self.user,
+                modified_by=self.user,
             )
 
     def test_spectrumplot_returns_200_with_valid_points(self):

--- a/YSE_App/view_utils.py
+++ b/YSE_App/view_utils.py
@@ -1446,6 +1446,8 @@ def spectrumplot(request, transient_id):
         spec_data = spectrum.transientspecdata_set.all()
         wave = np.array([s.wavelength for s in spec_data])
         flux = np.array([s.flux for s in spec_data])
+        if wave.size == 0 or flux.size == 0:
+            continue
         
         # Vectorized sorting and interpolation
         sort_idx = np.argsort(wave)
@@ -1459,7 +1461,10 @@ def spectrumplot(request, transient_id):
             'wave': wave_interp,
             'flux': flux_interp,
             'mjd': date_to_mjd(spectrum.obs_date.isoformat().split('+')[0]),
+            'label': f'{spectrum.instrument.name} - {spectrum.obs_date.strftime("%Y-%m-%d")}',
         })
+    if not spectra:
+        return django.http.HttpResponse('')
     
     # Process spectra and compute offsets
     dates = np.array([spec['mjd'] for spec in spectra])
@@ -1478,13 +1483,15 @@ def spectrumplot(request, transient_id):
         minval = sort_flux[round(n_pix * 0.05)] * 0.5
         maxval = sort_flux[round(n_pix * 0.95)] * 1.1
         scale = maxval - minval
+        if scale == 0:
+            scale = 1.0
         
         # Normalize flux
         norm_flux = (flux - minval) / scale + offset
         
         # Plot line
         p = ax.line(spec['wave'], norm_flux, color=color, muted_alpha=0.2)
-        legend_items.append((f'{spectrum.instrument.name} - {spectrum.obs_date.strftime("%Y-%m-%d")}', [p]))
+        legend_items.append((spec['label'], [p]))
     
     # Add legend
     legend = Legend(items=legend_items, location="bottom_right")

--- a/YSE_App/view_utils.py
+++ b/YSE_App/view_utils.py
@@ -1431,7 +1431,6 @@ def lightcurveplot_flux(request, transient_id, salt2=False):
 
 def spectrumplot(request, transient_id):
     _load_heavy_plot_stack()
-    tstart = time.time()
     
     # Fetch data with optimized queries
     transient = Transient.objects.get(pk=transient_id)
@@ -1512,7 +1511,6 @@ def spectrumplot(request, transient_id):
 
 def spectrumplot_summary(request, transient_id):
     _load_heavy_plot_stack()
-    tstart = time.time()
     transient = Transient.objects.get(pk=transient_id)
     dbspectra = SpectraService.GetAuthorizedTransientSpectrum_ByUser_ByTransient(request.user, transient_id, includeBadData=True).select_related()
     spectra = {}
@@ -1629,7 +1627,6 @@ def spectrumplotsingle(request, transient_id, spec_id):
     #transient_id = request.GET.get('transient_id')
     #spec_id = request.GET.get('spec_id')
     
-    tstart = time.time()
     print(transient_id,spec_id)
     transient = Transient.objects.get(pk=transient_id)
     spectra = SpectraService.GetAuthorizedTransientSpectrum_ByUser_ByTransient(request.user, transient_id, includeBadData=True)

--- a/YSE_App/view_utils.py
+++ b/YSE_App/view_utils.py
@@ -9,6 +9,7 @@ import django
 from django.conf import settings as djangoSettings
 from django.contrib.auth.decorators import login_required, permission_required
 from django.db import models, connection, reset_queries
+from django.db.models import Prefetch
 from django.http import HttpResponse, HttpResponseRedirect, JsonResponse
 from django.shortcuts import render, get_object_or_404, render
 from django.urls import reverse


### PR DESCRIPTION
## Summary

- Fix `spectrumplot` crash path in `YSE_App/view_utils.py` by skipping spectra with zero `TransientSpecData` rows before interpolation (`np.min`/`np.max`).
- Preserve per-spectrum legend metadata with each plotted series and use that metadata in legend generation (instead of leaked outer-loop state).
- Return an empty response when no plottable spectra remain, and guard zero-scale normalization.
- Add regression tests in `YSE_App/tests/test_post_merge_hotfix.py` for:
  - successful `spectrumplot` render with valid spec points
  - mixed empty + non-empty spectra returning 200 (no 500)

## Root cause

`develop` has a refactored/vectorized `spectrumplot` that can raise exceptions when authorized spectra include rows with no spec points, and legend labels were coupled to stale variable scope. This is consistent with `/yse_test/spectrumplot/11281/` returning 500 while `/yse/spectrumplot/11281/` remains healthy.

## Test plan

- [ ] `docker exec ysepz_web_container python3 manage.py test YSE_App.tests.test_post_merge_hotfix --noinput -v2`
- [ ] `docker exec ysepz_web_container python3 manage.py test YSE_App.tests.test_lightcurve YSE_App.tests.test_performance --noinput -v2`
- [ ] Manual: open `/transient_detail/2019np/` and verify `/spectrumplot/<id>/` returns 200

Note: Docker daemon was unavailable in this local environment (`docker.sock` missing), so CI/manual verification is required on host where daemon is running.

Made with [Cursor](https://cursor.com)