### PR TITLE
Security: group-aware comments and SQL access (issue #102)

### DIFF
--- a/YSE_App/api_views.py
+++ b/YSE_App/api_views.py
@@ -236,6 +236,12 @@ class LogViewSet(custom_viewsets.ListCreateRetrieveUpdateViewSet):
     serializer_class = LogSerializer
     permission_classes = (permissions.IsAuthenticated,)
 
+    def get_queryset(self):
+        from YSE_App.services.visibility import filter_transient_comments_for_user
+
+        qs = Log.objects.all().prefetch_related("groups")
+        return filter_transient_comments_for_user(qs, self.request.user)
+
 ### `Observation Task` ViewSets ###
 class TransientObservationTaskViewSet(custom_viewsets.ListCreateRetrieveUpdateViewSet):
     queryset = TransientObservationTask.objects.all()
@@ -503,8 +509,12 @@ class TransientCommentListCreate(generics.ListCreateAPIView):
 
     def get_queryset(self):
         from YSE_App.services.comments import transient_comment_queryset
+        from YSE_App.services.visibility import user_can_view_transient
 
-        return transient_comment_queryset(int(self.kwargs["transient_id"]))
+        transient_id = int(self.kwargs["transient_id"])
+        if not user_can_view_transient(self.request.user, transient_id):
+            return Log.objects.none()
+        return transient_comment_queryset(transient_id, user=self.request.user)
 
     def create(self, request, *args, **kwargs):
         from YSE_App.services.comments import create_transient_comment

--- a/YSE_App/api_views.py
+++ b/YSE_App/api_views.py
@@ -186,6 +186,12 @@ class TransientFollowupViewSet(custom_viewsets.ListCreateRetrieveUpdateViewSet):
     serializer_class = TransientFollowupSerializer
     permission_classes = (permissions.IsAuthenticated,)
 
+    def get_queryset(self):
+        from YSE_App.services.visibility import filter_transient_followups_for_user
+
+        qs = TransientFollowup.objects.all().prefetch_related("groups")
+        return filter_transient_followups_for_user(qs, self.request.user)
+
 class HostFollowupViewSet(custom_viewsets.ListCreateRetrieveUpdateViewSet):
     queryset = HostFollowup.objects.all()
     serializer_class = HostFollowupSerializer

--- a/YSE_App/data/ObservingResourceService.py
+++ b/YSE_App/data/ObservingResourceService.py
@@ -1,16 +1,6 @@
 from YSE_App.models import *
 from django.db.models import Q
-
-
-def GetUserGroupQuery(user):
-    user_groups = []
-    for g in user.groups.all():
-        user_groups.append(g.name)
-
-    no_group = Q(groups__isnull=True)
-    contains_group = Q(groups__name__in=user_groups)
-
-    return no_group, contains_group
+from YSE_App.services.visibility import get_user_group_query as GetUserGroupQuery
 
 def GetAuthorizedToOResource_ByUser(user):
     group_query_tuple = GetUserGroupQuery(user)

--- a/YSE_App/data/PhotometryService.py
+++ b/YSE_App/data/PhotometryService.py
@@ -1,16 +1,7 @@
 from YSE_App.models import *
 from django.db.models import Q
 from YSE_App.models import phot_models
-
-def GetUserGroupQuery(user):
-    user_groups = []
-    for g in user.groups.all():
-        user_groups.append(g.name)
-
-    no_group = Q(groups__isnull=True)
-    contains_group = Q(groups__name__in=user_groups)
-
-    return no_group, contains_group
+from YSE_App.services.visibility import get_user_group_query as GetUserGroupQuery
 
 def GetAuthorizedTransientPhotometry_ByUser(user):
     group_query_tuple = GetUserGroupQuery(user)

--- a/YSE_App/data/SpectraService.py
+++ b/YSE_App/data/SpectraService.py
@@ -1,16 +1,6 @@
 from YSE_App.models import *
 from django.db.models import Q
-
-
-def GetUserGroupQuery(user):
-    user_groups = []
-    for g in user.groups.all():
-        user_groups.append(g.name)
-
-    no_group = Q(groups__isnull=True)
-    contains_group = Q(groups__name__in=user_groups)
-
-    return no_group, contains_group
+from YSE_App.services.visibility import get_user_group_query as GetUserGroupQuery
 
 def GetAuthorizedTransientSpectrum_ByUser(user, includeBadData=True):
     group_query_tuple = GetUserGroupQuery(user)

--- a/YSE_App/form_views.py
+++ b/YSE_App/form_views.py
@@ -57,6 +57,7 @@ class AddTransientFollowupFormView(FormView):
 			instance = form.save(commit=False)
 			instance.created_by = self.request.user
 			instance.modified_by = self.request.user
+			instance.requested_by = self.request.user
 			if instance.classical_resource:
 				instance.valid_start = instance.classical_resource.begin_date_valid
 				instance.valid_stop = instance.classical_resource.end_date_valid

--- a/YSE_App/migrations/0005_log_visibility.py
+++ b/YSE_App/migrations/0005_log_visibility.py
@@ -1,0 +1,24 @@
+from django.conf import settings
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+        ("auth", "0012_alter_user_first_name_max_length"),
+        ("YSE_App", "0004_slackthreadlink"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="log",
+            name="is_public",
+            field=models.BooleanField(default=True),
+        ),
+        migrations.AddField(
+            model_name="log",
+            name="groups",
+            field=models.ManyToManyField(blank=True, to="auth.group"),
+        ),
+    ]

--- a/YSE_App/migrations/0006_followup_visibility.py
+++ b/YSE_App/migrations/0006_followup_visibility.py
@@ -1,0 +1,56 @@
+from django.conf import settings
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+        ("auth", "0012_alter_user_first_name_max_length"),
+        ("YSE_App", "0005_log_visibility"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="hostfollowup",
+            name="is_public",
+            field=models.BooleanField(default=True),
+        ),
+        migrations.AddField(
+            model_name="hostfollowup",
+            name="requested_by",
+            field=models.ForeignKey(
+                blank=True,
+                null=True,
+                on_delete=models.deletion.SET_NULL,
+                related_name="+",
+                to=settings.AUTH_USER_MODEL,
+            ),
+        ),
+        migrations.AddField(
+            model_name="transientfollowup",
+            name="is_public",
+            field=models.BooleanField(default=True),
+        ),
+        migrations.AddField(
+            model_name="transientfollowup",
+            name="requested_by",
+            field=models.ForeignKey(
+                blank=True,
+                null=True,
+                on_delete=models.deletion.SET_NULL,
+                related_name="+",
+                to=settings.AUTH_USER_MODEL,
+            ),
+        ),
+        migrations.AddField(
+            model_name="hostfollowup",
+            name="groups",
+            field=models.ManyToManyField(blank=True, to="auth.group"),
+        ),
+        migrations.AddField(
+            model_name="transientfollowup",
+            name="groups",
+            field=models.ManyToManyField(blank=True, to="auth.group"),
+        ),
+    ]

--- a/YSE_App/models/followup_models.py
+++ b/YSE_App/models/followup_models.py
@@ -1,4 +1,6 @@
 from django.db import models
+from django.contrib.auth.models import Group
+from django.contrib.auth.models import User
 from YSE_App.models.base import *
 from YSE_App.models.enum_models import *
 from YSE_App.models.telescope_resource_models import *
@@ -38,6 +40,13 @@ class Followup(BaseModel):
 	offset_star_dec = models.FloatField(null=True, blank=True)
 	offset_north = models.FloatField(null=True, blank=True)
 	offset_east = models.FloatField(null=True, blank=True)
+
+	# Collaboration visibility (default public; see YSE_App.services.visibility)
+	is_public = models.BooleanField(default=True)
+	requested_by = models.ForeignKey(
+		User, null=True, blank=True, on_delete=models.SET_NULL, related_name="+"
+	)
+	groups = models.ManyToManyField(Group, blank=True)
 
 class TransientFollowup(Followup):
 	### Entity relationships ###

--- a/YSE_App/models/log_models.py
+++ b/YSE_App/models/log_models.py
@@ -1,4 +1,5 @@
 from django.db import models
+from django.contrib.auth.models import Group
 from YSE_App.models.base import *
 from YSE_App.models.spectra_models import *
 from YSE_App.models.phot_models import *
@@ -40,6 +41,9 @@ class Log(BaseModel):
 	### Properties ###
 	# Required
 	comment = models.TextField()
+	# Collaboration visibility (see YSE_App.services.visibility)
+	is_public = models.BooleanField(default=True)
+	groups = models.ManyToManyField(Group, blank=True)
 
 	def __str__(self):
 		limit = 20

--- a/YSE_App/services/comments.py
+++ b/YSE_App/services/comments.py
@@ -2,23 +2,33 @@
 
 from __future__ import annotations
 
-from typing import Any, Dict, Optional
+from typing import Any, Dict, List, Optional
 
-from django.contrib.auth.models import User
+from django.contrib.auth.models import Group, User
+from rest_framework.exceptions import PermissionDenied
 
 from YSE_App.models import Log, Transient
+from YSE_App.services.visibility import (
+    default_comment_audience_groups,
+    filter_transient_comments_for_user,
+    user_can_view_transient,
+)
 
 
-def transient_comment_queryset(transient_id: int):
+def transient_comment_queryset(transient_id: int, user: Optional[User] = None):
     """Comments on the transient itself (not follow-up rows)."""
-    return (
+    qs = (
         Log.objects.filter(
             transient_id=transient_id,
             transient_followup__isnull=True,
         )
         .select_related("created_by")
+        .prefetch_related("groups")
         .order_by("-modified_date")
     )
+    if user is not None:
+        qs = filter_transient_comments_for_user(qs, user)
+    return qs
 
 
 def format_comment_datetime(dt) -> str:
@@ -46,13 +56,32 @@ def create_transient_comment(
     comment: str,
     user: User,
     notify: bool = True,
+    is_public: Optional[bool] = None,
+    audience_groups: Optional[List[Group]] = None,
 ) -> Log:
+    if not user_can_view_transient(user, transient.id):
+        raise PermissionDenied(
+            {"message": "You do not have access to comment on this transient."}
+        )
+
+    if is_public is None:
+        is_public = False
+    if audience_groups is None and not is_public:
+        audience_groups = default_comment_audience_groups(user, transient.id)
+        if not audience_groups:
+            # No collaboration groups to scope to (e.g. public-only transient).
+            is_public = True
+
     log = Log.objects.create(
         transient=transient,
         comment=comment,
         created_by=user,
         modified_by=user,
+        is_public=is_public,
     )
+    if audience_groups and not is_public:
+        log.groups.set(audience_groups)
+
     if notify:
         from YSE_App.services.notifications import notify_transient_comment
 

--- a/YSE_App/services/visibility.py
+++ b/YSE_App/services/visibility.py
@@ -1,0 +1,138 @@
+"""Shared group-based visibility helpers for YSE data and comments."""
+
+from __future__ import annotations
+
+from enum import Enum
+from typing import Iterable, List, Optional, Set, Union
+
+from django.contrib.auth.models import Group, User
+from django.db.models import Q, QuerySet
+
+
+class ResourceVisibilityPolicy(str, Enum):
+    """Default visibility when creating new rows (empty M2M = public on existing data)."""
+
+    PUBLIC = "public"
+    PRIVATE = "private"
+
+
+def user_group_names(user: User) -> List[str]:
+    if not user.is_authenticated:
+        return []
+    return list(user.groups.values_list("name", flat=True))
+
+
+def get_user_group_query(user: User):
+    """Same semantics as PhotometryService: ungrouped OR intersects user groups."""
+    names = user_group_names(user)
+    no_group = Q(groups__isnull=True)
+    contains_group = Q(groups__name__in=names)
+    return no_group, contains_group
+
+
+def object_has_groups(obj) -> bool:
+    return obj.groups.exists()
+
+
+def object_visible_to_user(user: User, obj) -> bool:
+    """Object with optional ``groups`` M2M (photometry, spectrum, resource, log)."""
+    if not user.is_authenticated:
+        return False
+    if user.is_staff or user.is_superuser:
+        return True
+    if not object_has_groups(obj):
+        return True
+    names = set(user_group_names(user))
+    obj_names = set(obj.groups.values_list("name", flat=True))
+    return bool(names.intersection(obj_names))
+
+
+def transient_visible_group_names(transient_id: int) -> Set[str]:
+    from YSE_App.models import TransientPhotometry, TransientSpectrum
+
+    names: Set[str] = set()
+    for qs in (
+        TransientPhotometry.objects.filter(transient_id=transient_id),
+        TransientSpectrum.objects.filter(transient_id=transient_id),
+    ):
+        for row in qs.prefetch_related("groups"):
+            names.update(row.groups.values_list("name", flat=True))
+    return names
+
+
+def shared_groups_for_transient(user: User, transient_id: int) -> QuerySet[Group]:
+    """Collaboration groups the user shares with restricted data on this transient."""
+    on_transient = transient_visible_group_names(transient_id)
+    if not on_transient:
+        return user.groups.all()
+    return user.groups.filter(name__in=on_transient)
+
+
+def user_can_view_transient(user: User, transient_id: int) -> bool:
+    """True if user may access this transient's collaboration surfaces (comments, etc.)."""
+    if not user.is_authenticated:
+        return False
+    if user.is_staff or user.is_superuser:
+        return True
+    from YSE_App.data import PhotometryService, SpectraService
+
+    if PhotometryService.GetAuthorizedTransientPhotometry_ByUser_ByTransient(
+        user, transient_id
+    ).exists():
+        return True
+    if SpectraService.GetAuthorizedTransientSpectrum_ByUser_ByTransient(
+        user, transient_id
+    ).exists():
+        return True
+    return False
+
+
+def default_comment_audience_groups(user: User, transient_id: int) -> List[Group]:
+    """Private-by-default: groups user shares with transient's restricted data."""
+    shared = list(shared_groups_for_transient(user, transient_id))
+    if shared:
+        return shared
+    return list(user.groups.all())
+
+
+def filter_transient_comments_for_user(queryset: QuerySet, user: User) -> QuerySet:
+    """Filter transient-level comment logs for read access."""
+    if user.is_staff or user.is_superuser:
+        return queryset
+    names = user_group_names(user)
+    return queryset.filter(
+        Q(is_public=True) | Q(groups__name__in=names)
+    ).distinct()
+
+
+def log_visible_to_user(user: User, log) -> bool:
+    if not user.is_authenticated:
+        return False
+    if user.is_staff or user.is_superuser:
+        return True
+    if getattr(log, "is_public", True):
+        return True
+    if not object_has_groups(log):
+        return False
+    names = set(user_group_names(user))
+    obj_names = set(log.groups.values_list("name", flat=True))
+    return bool(names.intersection(obj_names))
+
+
+def filter_transients_by_user_access(
+    user: User, transients: Union[QuerySet, Iterable],
+):
+    """Post-filter transients (e.g. after SQL Explorer) by photometry/spectrum access."""
+    if user.is_staff or user.is_superuser:
+        return transients
+    from YSE_App.models import Transient
+
+    if isinstance(transients, QuerySet):
+        ids = list(transients.values_list("id", flat=True))
+        allowed = [
+            pk
+            for pk in ids
+            if user_can_view_transient(user, pk)
+        ]
+        return transients.filter(id__in=allowed)
+    return [t for t in transients if user_can_view_transient(user, t.id)]

--- a/YSE_App/services/visibility.py
+++ b/YSE_App/services/visibility.py
@@ -136,3 +136,59 @@ def filter_transients_by_user_access(
         ]
         return transients.filter(id__in=allowed)
     return [t for t in transients if user_can_view_transient(user, t.id)]
+
+
+def _followup_linked_resource_group_q(user: User) -> Q:
+    """Q for follow-up visible via linked telescope resource groups."""
+    names = user_group_names(user)
+    return (
+        Q(classical_resource__groups__name__in=names)
+        | Q(too_resource__groups__name__in=names)
+        | Q(queued_resource__groups__name__in=names)
+    )
+
+
+def filter_transient_followups_for_user(queryset: QuerySet, user: User) -> QuerySet:
+    """Filter follow-up rows for read access (default public for legacy rows)."""
+    if user.is_staff or user.is_superuser:
+        return queryset
+    from YSE_App.data import PhotometryService, SpectraService
+
+    names = user_group_names(user)
+    phot_transients = PhotometryService.GetAuthorizedTransientPhotometry_ByUser(
+        user
+    ).values_list("transient_id", flat=True)
+    spec_transients = SpectraService.GetAuthorizedTransientSpectrum_ByUser(
+        user
+    ).values_list("transient_id", flat=True)
+    return queryset.filter(
+        Q(transient_id__in=phot_transients) | Q(transient_id__in=spec_transients),
+        Q(is_public=True)
+        | Q(groups__name__in=names)
+        | Q(requested_by=user)
+        | _followup_linked_resource_group_q(user),
+    ).distinct()
+
+
+def followup_visible_to_user(user: User, followup) -> bool:
+    if not user.is_authenticated:
+        return False
+    if user.is_staff or user.is_superuser:
+        return True
+    transient_id = getattr(followup, "transient_id", None)
+    if transient_id is not None and not user_can_view_transient(user, transient_id):
+        return False
+    if getattr(followup, "is_public", True):
+        return True
+    if followup.requested_by_id == user.id:
+        return True
+    if object_has_groups(followup):
+        names = set(user_group_names(user))
+        obj_names = set(followup.groups.values_list("name", flat=True))
+        if names.intersection(obj_names):
+            return True
+    for attr in ("classical_resource", "too_resource", "queued_resource"):
+        res = getattr(followup, attr, None)
+        if res is not None and object_visible_to_user(user, res):
+            return True
+    return False

--- a/YSE_App/tests/test_group_visibility.py
+++ b/YSE_App/tests/test_group_visibility.py
@@ -3,10 +3,12 @@
 from django.contrib.auth.models import Group, User
 from django.test import Client, TestCase
 from django.urls import reverse
-from YSE_App.models import Log, TransientPhotometry
+from YSE_App.models import Log, TransientFollowup, TransientPhotometry
 from YSE_App.services.comments import create_transient_comment, transient_comment_queryset
 from YSE_App.services.visibility import (
     filter_transient_comments_for_user,
+    filter_transient_followups_for_user,
+    followup_visible_to_user,
     user_can_view_transient,
 )
 from YSE_App.tests.fixtures_minimal import (
@@ -110,3 +112,66 @@ class GroupVisibilityTests(TestCase):
             content_type="application/json",
         )
         self.assertEqual(response.status_code, 403)
+
+    def _create_followup(self, user, *, is_public=True, groups=None):
+        from YSE_App.models import FollowupStatus
+        from django.utils import timezone
+        from datetime import timedelta
+
+        status, _ = FollowupStatus.objects.get_or_create(
+            name="sec-test-requested",
+            defaults={
+                "created_by": user,
+                "modified_by": user,
+            },
+        )
+        now = timezone.now()
+        followup = TransientFollowup.objects.create(
+            transient=self.transient,
+            status=status,
+            valid_start=now,
+            valid_stop=now + timedelta(days=7),
+            is_public=is_public,
+            requested_by=user,
+            created_by=user,
+            modified_by=user,
+        )
+        if groups:
+            followup.groups.set(groups)
+        return followup
+
+    def test_private_followup_not_visible_to_other_group(self):
+        followup = self._create_followup(
+            self.user_a,
+            is_public=False,
+            groups=[self.group_a],
+        )
+        self.assertFalse(
+            followup_visible_to_user(self.user_b, followup),
+        )
+        qs = filter_transient_followups_for_user(
+            TransientFollowup.objects.filter(transient=self.transient),
+            self.user_b,
+        )
+        self.assertEqual(qs.count(), 0)
+
+    def test_public_followup_visible_to_authorized_user(self):
+        followup = self._create_followup(self.user_a, is_public=True)
+        self.assertTrue(
+            followup_visible_to_user(self.user_a, followup),
+        )
+        qs = filter_transient_followups_for_user(
+            TransientFollowup.objects.filter(transient=self.transient),
+            self.user_a,
+        )
+        self.assertEqual(qs.count(), 1)
+
+    def test_api_followup_list_denied_without_transient_access(self):
+        self._create_followup(self.user_a, is_public=True)
+        client = Client()
+        client.force_login(self.user_b)
+        response = client.get("/api/transientfollowups/")
+        self.assertEqual(response.status_code, 200)
+        payload = response.json()
+        results = payload.get("results", payload)
+        self.assertEqual(len(results), 0)

--- a/YSE_App/tests/test_group_visibility.py
+++ b/YSE_App/tests/test_group_visibility.py
@@ -1,0 +1,112 @@
+"""Group-based visibility for comments and shared helpers (issue #102)."""
+
+from django.contrib.auth.models import Group, User
+from django.test import Client, TestCase
+from django.urls import reverse
+from YSE_App.models import Log, TransientPhotometry
+from YSE_App.services.comments import create_transient_comment, transient_comment_queryset
+from YSE_App.services.visibility import (
+    filter_transient_comments_for_user,
+    user_can_view_transient,
+)
+from YSE_App.tests.fixtures_minimal import (
+    attach_synthetic_photometry,
+    create_minimal_transient,
+    create_test_user,
+)
+
+
+class GroupVisibilityTests(TestCase):
+    def setUp(self):
+        self.group_a, _ = Group.objects.get_or_create(name="sec-test-a")
+        self.group_b, _ = Group.objects.get_or_create(name="sec-test-b")
+
+        self.user_a = create_test_user("sec_user_a", is_staff=False)
+        self.user_a.groups.add(self.group_a)
+
+        self.user_b = create_test_user("sec_user_b", is_staff=False)
+        self.user_b.groups.add(self.group_b)
+
+        admin = create_test_user("sec_admin", is_staff=True)
+        self.transient = create_minimal_transient(admin, name="secvis01")
+        self.restricted_phot = attach_synthetic_photometry(
+            admin, self.transient, n_points=3
+        )
+        self.restricted_phot.groups.add(self.group_a)
+
+    def test_user_a_can_view_transient_with_group_a_photometry(self):
+        self.assertTrue(
+            user_can_view_transient(self.user_a, self.transient.id),
+        )
+
+    def test_user_b_cannot_view_restricted_transient(self):
+        self.assertFalse(
+            user_can_view_transient(self.user_b, self.transient.id),
+        )
+
+    def test_private_comment_not_visible_to_other_group(self):
+        log = create_transient_comment(
+            transient=self.transient,
+            comment="group A only",
+            user=self.user_a,
+            notify=False,
+            is_public=False,
+            audience_groups=[self.group_a],
+        )
+        self.assertFalse(log.is_public)
+
+        qs_a = transient_comment_queryset(self.transient.id, user=self.user_a)
+        self.assertEqual(qs_a.count(), 1)
+
+        qs_b = transient_comment_queryset(self.transient.id, user=self.user_b)
+        self.assertEqual(qs_b.count(), 0)
+
+        self.assertIn(
+            log,
+            list(filter_transient_comments_for_user(Log.objects.all(), self.user_a)),
+        )
+
+    def test_public_comment_visible_to_authorized_user(self):
+        create_transient_comment(
+            transient=self.transient,
+            comment="public to collaborators",
+            user=self.user_a,
+            notify=False,
+            is_public=True,
+        )
+        qs_a = transient_comment_queryset(self.transient.id, user=self.user_a)
+        self.assertEqual(qs_a.count(), 1)
+
+    def test_api_list_denied_without_transient_access(self):
+        create_transient_comment(
+            transient=self.transient,
+            comment="hidden",
+            user=self.user_a,
+            notify=False,
+            is_public=True,
+        )
+        url = reverse(
+            "api-transient-comments",
+            kwargs={"transient_id": self.transient.id},
+        )
+        client = Client()
+        client.force_login(self.user_b)
+        response = client.get(url)
+        self.assertEqual(response.status_code, 200)
+        payload = response.json()
+        results = payload.get("results", payload)
+        self.assertEqual(len(results), 0)
+
+    def test_api_create_denied_without_transient_access(self):
+        url = reverse(
+            "api-transient-comments",
+            kwargs={"transient_id": self.transient.id},
+        )
+        client = Client()
+        client.force_login(self.user_b)
+        response = client.post(
+            url,
+            {"comment": "should fail", "transient": self.transient.id},
+            content_type="application/json",
+        )
+        self.assertEqual(response.status_code, 403)

--- a/YSE_App/views.py
+++ b/YSE_App/views.py
@@ -1081,6 +1081,7 @@ def transient_detail(request, slug):
         transient_obj = transient_matches[0]
         transient_id = transient_obj.id
         from YSE_App.services.comments import transient_comment_queryset
+        from YSE_App.services.visibility import filter_transient_followups_for_user
 
         logs = list(
             transient_comment_queryset(transient_id, user=request.user)
@@ -1120,23 +1121,26 @@ def transient_detail(request, slug):
                     gwimages = GWCandidateImage.objects.filter(gw_candidate__name = gwcand[0].name)
 
         followups = list(
-            TransientFollowup.objects.filter(transient__pk=transient_id)
-            .select_related(
-                'status',
-                'classical_resource',
-                'too_resource',
-                'queued_resource',
-                'classical_resource__telescope',
-                'too_resource__telescope',
-                'queued_resource__telescope',
-            )
-            .prefetch_related(
-                Prefetch(
-                    'transientobservationtask_set',
-                    queryset=TransientObservationTask.objects.select_related(
-                        'instrument_config', 'status'
-                    ),
+            filter_transient_followups_for_user(
+                TransientFollowup.objects.filter(transient__pk=transient_id)
+                .select_related(
+                    'status',
+                    'classical_resource',
+                    'too_resource',
+                    'queued_resource',
+                    'classical_resource__telescope',
+                    'too_resource__telescope',
+                    'queued_resource__telescope',
                 )
+                .prefetch_related(
+                    Prefetch(
+                        'transientobservationtask_set',
+                        queryset=TransientObservationTask.objects.select_related(
+                            'instrument_config', 'status'
+                        ),
+                    )
+                ),
+                request.user,
             )
         )
         if followups:

--- a/YSE_App/views.py
+++ b/YSE_App/views.py
@@ -249,8 +249,13 @@ def personaldashboard(request):
                 )
 
     if all_transient_names:
+        from YSE_App.services.visibility import filter_transients_by_user_access
+
         base_transients = annotate_dashboard_transient_fields(
             Transient.objects.filter(name__in=all_transient_names).order_by('-disc_date')
+        )
+        base_transients = filter_transients_by_user_access(
+            request.user, base_transients
         )
     else:
         base_transients = Transient.objects.none()
@@ -1077,7 +1082,9 @@ def transient_detail(request, slug):
         transient_id = transient_obj.id
         from YSE_App.services.comments import transient_comment_queryset
 
-        logs = list(transient_comment_queryset(transient_id))
+        logs = list(
+            transient_comment_queryset(transient_id, user=request.user)
+        )
 
         alt_names = AlternateTransientNames.objects.filter(transient__pk=transient_id)
 
@@ -1306,7 +1313,7 @@ def comments_fragment(request, slug):
     from YSE_App.services.comments import transient_comment_queryset
 
     transient = get_object_or_404(Transient, slug=slug)
-    logs = list(transient_comment_queryset(transient.id))
+    logs = list(transient_comment_queryset(transient.id, user=request.user))
     from django.utils import timezone as dj_timezone
 
     comment_cutoff = dj_timezone.now() - datetime.timedelta(days=1)
@@ -1515,6 +1522,9 @@ def download_bulk_photometry(request, query_title):
         cursor.execute(query[0].sql.replace('%','%%'), ())
         transients = Transient.objects.filter(name__in=(x[0] for x in cursor)).order_by('-disc_date')
         cursor.close()
+        from YSE_App.services.visibility import filter_transients_by_user_access
+
+        transients = filter_transients_by_user_access(user, transients)
 
     elif getattr(yse_python_queries,query_title):
         transients = getattr(yse_python_queries,query_title)()

--- a/YSE_App/yse_utils/yse_view_utils.py
+++ b/YSE_App/yse_utils/yse_view_utils.py
@@ -517,6 +517,8 @@ def init_draw_transients(request):
 					cursor.execute(query.sql.replace('%','%%'), ())
 					transients = Transient.objects.filter(name__in=(x[0] for x in cursor)).order_by('-disc_date')
 					cursor.close()
+					from YSE_App.services.visibility import filter_transients_by_user_access
+					transients = filter_transients_by_user_access(request.user, transients)
 				else:
 					query = UserQuery.objects.filter(python_query = unquote(query_name))
 					if not len(query): return Http404('Invalid Query')

--- a/YSE_PZ/settings.py
+++ b/YSE_PZ/settings.py
@@ -199,9 +199,13 @@ else:
 
 EXPLORER_CONNECTIONS = { 'Explorer': 'explorer' }
 EXPLORER_DEFAULT_CONNECTION = 'explorer'
-# Allow all users to access and modify SQL Explorer queries.
-EXPLORER_PERMISSION_VIEW = lambda u: u
-EXPLORER_PERMISSION_CHANGE = lambda u: u
+# SQL Explorer: staff only (see issue #102). Dashboard SQL is post-filtered separately.
+EXPLORER_PERMISSION_VIEW = lambda u: u.is_authenticated and (
+    u.is_staff or u.is_superuser
+)
+EXPLORER_PERMISSION_CHANGE = lambda u: u.is_authenticated and (
+    u.is_staff or u.is_superuser
+)
 
 REST_FRAMEWORK = {
     # Use Django's standard `django.contrib.auth` permissions,

--- a/docs/security-groups.md
+++ b/docs/security-groups.md
@@ -7,16 +7,18 @@ YSE uses Django **collaboration groups** (`auth.Group`) on photometry, spectra, 
 - **Empty `groups` M2M** on photometry/spectra/resources: visible to all logged-in users (unchanged).
 - **New transient comments**: private by default (`Log.is_public=False` with `Log.groups` set to shared collaboration groups). Opt-in `is_public=True` for all collaborators who can open the transient.
 - **Legacy comments** (before migration `0005_log_visibility`): `is_public=True`, no groups — unchanged visibility.
+- **Follow-up requests** (`TransientFollowup`): default **public** (`is_public=True`). Restrict with `is_public=False` and optional `groups` M2M; `requested_by` is set on create.
 
 ## Code
 
-- [`YSE_App/services/visibility.py`](../YSE_App/services/visibility.py) — shared helpers
+- [`YSE_App/services/visibility.py`](../YSE_App/services/visibility.py) — shared helpers (`filter_transient_followups_for_user`, etc.)
 - [`YSE_App/services/comments.py`](../YSE_App/services/comments.py) — comment create/list filtering
 
 ## SQL Explorer
 
 Staff-only (`EXPLORER_PERMISSION_VIEW` / `CHANGE` in settings). Dashboard and canvas SQL results are post-filtered with `filter_transients_by_user_access`.
 
-## Follow-ups
+## Remaining ([#102](https://github.com/Young-Supernova-Experiment/YSE_PZ/issues/102))
 
-Per-group Slack ([#100](https://github.com/Young-Supernova-Experiment/YSE_PZ/issues/100)), follow-up `is_public` filtering, and DRF hardening remain on [#102](https://github.com/Young-Supernova-Experiment/YSE_PZ/issues/102).
+- Per-group Slack ([#100](https://github.com/Young-Supernova-Experiment/YSE_PZ/issues/100))
+- DRF hardening (`TransientViewSet`, export headers, notifications)

--- a/docs/security-groups.md
+++ b/docs/security-groups.md
@@ -1,0 +1,22 @@
+# Group-based access control
+
+YSE uses Django **collaboration groups** (`auth.Group`) on photometry, spectra, and telescope resources. Survey `ObservationGroup` on transients is metadata only.
+
+## Rules
+
+- **Empty `groups` M2M** on photometry/spectra/resources: visible to all logged-in users (unchanged).
+- **New transient comments**: private by default (`Log.is_public=False` with `Log.groups` set to shared collaboration groups). Opt-in `is_public=True` for all collaborators who can open the transient.
+- **Legacy comments** (before migration `0005_log_visibility`): `is_public=True`, no groups — unchanged visibility.
+
+## Code
+
+- [`YSE_App/services/visibility.py`](../YSE_App/services/visibility.py) — shared helpers
+- [`YSE_App/services/comments.py`](../YSE_App/services/comments.py) — comment create/list filtering
+
+## SQL Explorer
+
+Staff-only (`EXPLORER_PERMISSION_VIEW` / `CHANGE` in settings). Dashboard and canvas SQL results are post-filtered with `filter_transients_by_user_access`.
+
+## Follow-ups
+
+Per-group Slack ([#100](https://github.com/Young-Supernova-Experiment/YSE_PZ/issues/100)), follow-up `is_public` filtering, and DRF hardening remain on [#102](https://github.com/Young-Supernova-Experiment/YSE_PZ/issues/102).

--- a/docs/ui-workflow-roadmap.md
+++ b/docs/ui-workflow-roadmap.md
@@ -98,6 +98,7 @@ docker exec ysepz_web_container python3 manage.py test YSE_App.tests.test_page_l
 | Phase | Branch | Issues | Theme |
 |-------|--------|--------|--------|
 | **2** | *(see §4)* | #49–#58, #33 | *(shipped on `ui/phase-2-comments-slack`)* |
+| **2b** | `ui/security-group-access` | [#102](https://github.com/Young-Supernova-Experiment/YSE_PZ/issues/102) | Group visibility module, private comments, Explorer staff-only |
 | **3** | `ui/phase-3-night-requests` | #59–#69, T3-1 #34 | `ClassicalNightRequest`, priority, night-scoped queryset fixes |
 | **4** | `ui/phase-4-classical-scheduler` | #70–#78, T4-1 #35 | Greedy scheduler + planner UI + export (**C**) |
 | **5** | `ui/phase-5-dq-bitmask` | #79–#85, T5-1 #36 | `quality_mask` dual-write, filters, plot muting |
@@ -158,6 +159,7 @@ Fixes #16 Fixes #17 Fixes #18 Fixes #19 Fixes #20 Fixes #21 Fixes #22 Fixes #23
 | 0 | `ui/phase-0-bugfixes` |
 | 1 | `ui/phase-1-theme` |
 | 2 | `ui/phase-2-comments-slack` |
+| 2b | `ui/security-group-access` |
 | 3 | `ui/phase-3-night-requests` |
 | 4 | `ui/phase-4-classical-scheduler` |
 | 5 | `ui/phase-5-dq-bitmask` |

--- a/docs/ui-workflow-roadmap.md
+++ b/docs/ui-workflow-roadmap.md
@@ -98,7 +98,7 @@ docker exec ysepz_web_container python3 manage.py test YSE_App.tests.test_page_l
 | Phase | Branch | Issues | Theme |
 |-------|--------|--------|--------|
 | **2** | *(see §4)* | #49–#58, #33 | *(shipped on `ui/phase-2-comments-slack`)* |
-| **2b** | `ui/security-group-access` | [#102](https://github.com/Young-Supernova-Experiment/YSE_PZ/issues/102) | Group visibility module, private comments, Explorer staff-only |
+| **2b** | `ui/security-group-access` → [PR #104](https://github.com/Young-Supernova-Experiment/YSE_PZ/pull/104) | [#102](https://github.com/Young-Supernova-Experiment/YSE_PZ/issues/102) — visibility module, private comments, Explorer staff-only |
 | **3** | `ui/phase-3-night-requests` | #59–#69, T3-1 #34 | `ClassicalNightRequest`, priority, night-scoped queryset fixes |
 | **4** | `ui/phase-4-classical-scheduler` | #70–#78, T4-1 #35 | Greedy scheduler + planner UI + export (**C**) |
 | **5** | `ui/phase-5-dq-bitmask` | #79–#85, T5-1 #36 | `quality_mask` dual-write, filters, plot muting |


### PR DESCRIPTION
## Summary

First pass on [#102](https://github.com/Young-Supernova-Experiment/YSE_PZ/issues/102): shared visibility helpers, **private-by-default** new transient comments, filtered comment API/UI/`LogViewSet`, **staff-only** SQL Explorer, and post-filtering of dashboard/canvas/export SQL transient lists.

**Stacked on [PR #103](https://github.com/Young-Supernova-Experiment/YSE_PZ/pull/103)** until phase 2 merges; then rebase onto `develop`.

## Changes

- `YSE_App/services/visibility.py` — `get_user_group_query`, `user_can_view_transient`, comment filtering
- `Log.is_public` + `Log.groups` (migration `0005_log_visibility`); legacy rows stay `is_public=True`
- Photometry/spectra/resource services import shared group query (plot behavior unchanged)
- `docs/security-groups.md`

## Not in this PR (still #102 / #100 / #101)

- Follow-up `is_public` + filtering
- Per-group Slack (`GroupSlackIntegration`)
- Create-time audience UI checkbox (defaults applied in code)
- Narrow `TransientViewSet` / export header redaction

## Test plan

- [ ] `python manage.py migrate`
- [ ] `python manage.py test YSE_App.tests.test_group_visibility YSE_App.tests.test_phase2_comments`
- [ ] Manual: user in group A cannot see group A–only comment as user B; staff can use `/explorer/`


Made with [Cursor](https://cursor.com)