### PR TITLE
fix(docker): use YSE org GHCR image instead of davecoulter

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,6 +20,8 @@ This fork’s day-to-day development targets **`main`** on [astrofoley/YSE_PZ](h
 
 ## Local Docker
 
+Web container image: **`ghcr.io/young-supernova-experiment/yse_pz:latest`** from [Young-Supernova-Experiment/YSE_PZ](https://github.com/Young-Supernova-Experiment/YSE_PZ) (not the legacy `davecoulter` GHCR image). `yse-docker.sh up` pulls this image; your clone is mounted at `/app`.
+
 ### First-time setup
 
 ```bash

--- a/docker/Dockerfile.web.dev
+++ b/docker/Dockerfile.web.dev
@@ -1,6 +1,6 @@
-FROM ghcr.io/davecoulter/yse_pz:latest
-LABEL description="Ubuntu image for YSEPZ"
-LABEL maintainer="Dave Coulter (dcoulter@ucsc.edu)"
+FROM ghcr.io/young-supernova-experiment/yse_pz:latest
+LABEL description="YSE-PZ web dev layer (Young Supernova Experiment)"
+LABEL org.opencontainers.image.source="https://github.com/Young-Supernova-Experiment/YSE_PZ"
 
 SHELL ["/bin/bash", "-c"]
 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 services:
     web:
         container_name: ysepz_web_container
-        image: "ghcr.io/davecoulter/yse_pz:latest"
+        image: "ghcr.io/young-supernova-experiment/yse_pz:latest"
         platform: linux/amd64
         working_dir: /app
         volumes:

--- a/docker/scripts/prune-yse-docker.sh
+++ b/docker/scripts/prune-yse-docker.sh
@@ -20,7 +20,7 @@ fi
 
 echo "==> Removing unused YSE web images (keeping images used by ysepz_* containers)..."
 YSE_REPOS=(
-  "ghcr.io/davecoulter/yse_pz"
+  "ghcr.io/young-supernova-experiment/yse_pz"
   "local/yse_pz_web"
 )
 

--- a/docker/scripts/yse-docker.sh
+++ b/docker/scripts/yse-docker.sh
@@ -16,6 +16,8 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 DOCKER_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 cd "$DOCKER_DIR"
 
+YSE_GHCR_IMAGE="${YSE_GHCR_IMAGE:-ghcr.io/young-supernova-experiment/yse_pz:latest}"
+
 COMPOSE=(docker compose -f docker-compose.yml)
 if [[ "${YSE_DOCKER_BUILD_LOCAL:-0}" == "1" ]]; then
   COMPOSE+=( -f docker-compose.dev.yml )
@@ -70,11 +72,11 @@ run_collectstatic() {
 }
 
 usage() {
-  cat <<'EOF'
+  cat <<EOF
 YSE Docker helper (auto-prunes superseded images after success)
 
   yse-docker.sh up       Start stack (docker compose up -d)
-  yse-docker.sh pull     Pull published web image (ghcr.io/davecoulter/yse_pz:latest) and prune old copies
+  yse-docker.sh pull     Pull published web image ($YSE_GHCR_IMAGE) and prune old copies
   yse-docker.sh rebuild  Build local dev web image, start stack, aggressive prune
   yse-docker.sh prune    Prune only (--aggressive optional second arg)
   yse-docker.sh down     Stop stack (does not delete MySQL volume)
@@ -99,7 +101,7 @@ case "$cmd" in
     warn_if_static_incomplete
     ;;
   pull)
-    docker pull ghcr.io/davecoulter/yse_pz:latest
+    docker pull "$YSE_GHCR_IMAGE"
     run_prune aggressive
     ;;
   rebuild)


### PR DESCRIPTION
## Summary

**Option A:** Same workflow as `develop` — pull a pre-built web image and mount the repo at `/app`. Only the registry changes:

| Before | After |
|--------|-------|
| `ghcr.io/davecoulter/yse_pz:latest` | `ghcr.io/young-supernova-experiment/yse_pz:latest` |

Fixes #105. Build-from-source without any registry is deferred to #107.

## Changes (5 files)

- `docker/docker-compose.yml` — default web `image`
- `docker/Dockerfile.web.dev` — `FROM` for `yse-docker.sh rebuild` / `YSE_DOCKER_BUILD_LOCAL=1`
- `docker/scripts/yse-docker.sh` — `pull` + `YSE_GHCR_IMAGE` default
- `docker/scripts/prune-yse-docker.sh` — prune org image, not davecoulter
- `CONTRIBUTING.md` — document org GHCR URL

## Prerequisite

**Publish** `ghcr.io/young-supernova-experiment/yse_pz:latest` to the org GHCR (one-time: tag/push from the current working davecoulter image or rebuild). Until then, `docker compose pull` / CI will fail on the new URL — expected.

## Test plan

- [x] Org image published to GHCR
- [ ] `./docker/scripts/yse-docker.sh pull` succeeds
- [ ] `./docker/scripts/yse-docker.sh up` — no davecoulter pull; login page loads
- [ ] CI `docker-test` green
- [ ] `grep -r davecoulter docker/docker-compose.yml docker/Dockerfile.web.dev docker/scripts/` — no active refs (web_image_history archives unchanged)