### PR TITLE
Fix post-merge UI regressions (plots, tabs, pagination, magnitudes)

### DIFF
--- a/YSE_App/common/filter_display.py
+++ b/YSE_App/common/filter_display.py
@@ -1,0 +1,179 @@
+"""
+Canonical filter colors (Swope / PS1 uBVgrizy) and telescope symbol shapes for LC plots.
+
+Filter names like r-ZTF, r-WFT, and Swope r map to the same color. Telescope families
+(ZTF, PS1, Swope, …) share a Bokeh marker shape regardless of filter.
+"""
+
+from __future__ import annotations
+
+# Swope / PS1 uBVgrizy palette (matches YSE_App_photometricband seed values).
+FILTER_COLORS = {
+    'u': '#ff7f0e',
+    'B': '#1f77b4',
+    'V': '#8FBC8F',
+    'g': '#008000',
+    'r': '#DC143C',
+    'i': '#8c465b',
+    'z': '#800080',
+    'y': '#C9A227',
+    'w': '#EBBE0C',
+}
+
+# Lowercase alias -> canonical filter key in FILTER_COLORS.
+FILTER_ALIASES = {
+    'u': 'u',
+    'up': 'u',
+    'u-johnson': 'u',
+    'u-ps1': 'u',
+    'b': 'B',
+    'b-johnson': 'B',
+    'v': 'V',
+    'v-johnson': 'V',
+    'v-crts': 'V',
+    'v-crts-crts': 'V',
+    'g': 'g',
+    'gp': 'g',
+    'g-ztf': 'g',
+    'g-wft': 'g',
+    'g-sloan': 'g',
+    'g-ptf': 'g',
+    'g-sm': 'g',
+    'g-sm-skymapper': 'g',
+    'cyan': 'g',
+    'cyan-atlas': 'g',
+    'r': 'r',
+    'rp': 'r',
+    'r-ztf': 'r',
+    'r-wft': 'r',
+    'r-sloan': 'r',
+    'r-ptf': 'r',
+    'r-cousins': 'r',
+    'r-sm-skymapper': 'r',
+    'orange': 'r',
+    'orange-atlas': 'r',
+    'i': 'i',
+    'ip': 'i',
+    'i-ztf': 'i',
+    'i-sloan': 'i',
+    'i-ptf': 'i',
+    'i-cousins': 'i',
+    'z': 'z',
+    'zp': 'z',
+    'z-sloan': 'z',
+    'y': 'y',
+    'y-ps1': 'y',
+    'w': 'w',
+    'w-ps1': 'w',
+}
+
+_BASE_FILTER_KEYS = frozenset({'u', 'b', 'v', 'g', 'r', 'i', 'z', 'y', 'w', 'up', 'gp', 'rp', 'ip', 'zp'})
+
+# Instrument / telescope name substrings -> Bokeh glyph.
+TELESCOPE_SYMBOL_RULES = (
+    (('ztf',), 'diamond'),
+    (('gpc1', 'ps1', 'pan-starrs', 'panstarrs'), 'square'),
+    (('swope',), 'circle'),
+    (('acam', 'atlas'), 'asterisk'),
+    (('direct', 'p200'), 'hex'),
+    (('sinistro', 'pixis', 'lco', 'lcogt'), 'dash'),
+    (('acp', 'decam', 'decam'), 'star'),
+    (('soar', 'sta1600'), 'triangle'),
+    (('ptf',), 'cross'),
+    (('swift', 'uvot'), 'diamond'),
+    (('hst', 'wfc3', 'acs'), 'square'),
+)
+
+_FALLBACK_COLORS = ('#8dd3c7', '#bebada', '#fb8072', '#80b1d3', '#fdb462', '#b3de69', '#fccde5', '#d9d9d9')
+
+
+def normalize_filter_name(band_name: str | None) -> str | None:
+    """Map a band name (e.g. r-ZTF, r-WFT, g-Sloan) to a canonical uBVgrizy key."""
+    if not band_name:
+        return None
+    lower = band_name.strip().lower()
+    if lower in FILTER_ALIASES:
+        return FILTER_ALIASES[lower]
+    if 'cyan' in lower:
+        return 'g'
+    if 'orange' in lower:
+        return 'r'
+    base = lower.split('-')[0]
+    if base in _BASE_FILTER_KEYS:
+        return FILTER_ALIASES.get(base, base)
+    if base == 'b':
+        return 'B'
+    if base == 'v':
+        return 'V'
+    return None
+
+
+def band_display_color(
+    band_name: str | None,
+    disp_color: str | None = None,
+    *,
+    fallback_index: int = 0,
+) -> str:
+    """Resolve plot color: canonical filter family first, then DB value, then palette."""
+    canonical = normalize_filter_name(band_name)
+    if canonical and canonical in FILTER_COLORS:
+        return FILTER_COLORS[canonical]
+    if disp_color and disp_color != 'None':
+        return disp_color
+    return _FALLBACK_COLORS[fallback_index % len(_FALLBACK_COLORS)]
+
+
+def telescope_display_symbol(
+    instrument_name: str | None,
+    disp_symbol: str | None = None,
+) -> str:
+    """Resolve Bokeh marker from telescope family (shape groups by instrument)."""
+    inst_lower = (instrument_name or '').lower()
+    for patterns, symbol in TELESCOPE_SYMBOL_RULES:
+        if any(pat in inst_lower for pat in patterns):
+            return symbol
+    if disp_symbol and disp_symbol not in (None, 'None', 'inverted_triangle'):
+        return disp_symbol
+    return 'triangle'
+
+
+def filter_color_groups_for_display() -> list[dict]:
+    """Human-readable color groups for docs / chat (filter family -> example names)."""
+    groups = []
+    examples = {
+        'u': ['u', 'u-PS1', 'up (Sinistro)'],
+        'B': ['B', 'B-Johnson'],
+        'V': ['V', 'V-Johnson', 'V-crts'],
+        'g': ['g', 'g-ZTF', 'g-WFT', 'g-Sloan', 'g-PTF', 'cyan-ATLAS'],
+        'r': ['r', 'r-ZTF', 'r-WFT', 'r-Sloan', 'R-Cousins', 'orange-ATLAS'],
+        'i': ['i', 'i-ZTF', 'i-Sloan', 'I-Cousins', 'ip'],
+        'z': ['z', 'z-Sloan', 'zp'],
+        'y': ['y', 'y-PS1'],
+        'w': ['w', 'w-PS1'],
+    }
+    for key, color in FILTER_COLORS.items():
+        groups.append({
+            'filter': key,
+            'color': color,
+            'examples': examples.get(key, [key]),
+        })
+    return groups
+
+
+def telescope_symbol_groups_for_display() -> list[dict]:
+    """Human-readable telescope -> symbol groups."""
+    labels = {
+        'diamond': 'ZTF, Swift/UVOT',
+        'square': 'PS1 (GPC1), HST',
+        'circle': 'Swope',
+        'asterisk': 'ATLAS (ACAM)',
+        'hex': 'P200 Direct',
+        'dash': 'LCO Sinistro / PIXIS',
+        'star': 'DECam (ACP)',
+        'triangle': 'SOAR / STA1600 (default fallback)',
+        'cross': 'PTF',
+    }
+    seen = {}
+    for _patterns, symbol in TELESCOPE_SYMBOL_RULES:
+        seen.setdefault(symbol, labels.get(symbol, symbol))
+    return [{'symbol': sym, 'telescopes': desc} for sym, desc in seen.items()]

--- a/YSE_App/common/filter_display.py
+++ b/YSE_App/common/filter_display.py
@@ -69,6 +69,20 @@ FILTER_ALIASES = {
 
 _BASE_FILTER_KEYS = frozenset({'u', 'b', 'v', 'g', 'r', 'i', 'z', 'y', 'w', 'up', 'gp', 'rp', 'ip', 'zp'})
 
+# Instrument / telescope name substrings -> short legend label (e.g. ZTF-Cam -> ZTF).
+TELESCOPE_SHORT_LABELS = (
+    (('ztf', 'uvot'), 'ZTF'),
+    (('gpc1', 'ps1', 'pan-starrs', 'panstarrs'), 'PS1'),
+    (('swope',), 'Swope'),
+    (('acam', 'atlas'), 'ATLAS'),
+    (('direct', 'p200'), 'P200'),
+    (('sinistro', 'pixis', 'lco', 'lcogt'), 'LCO'),
+    (('acp', 'decam'), 'DECam'),
+    (('sta1600', 'soar'), 'SOAR'),
+    (('ptf',), 'PTF'),
+    (('hst', 'acs', 'wfc3'), 'HST'),
+)
+
 # Instrument / telescope name substrings -> Bokeh glyph.
 TELESCOPE_SYMBOL_RULES = (
     (('ztf',), 'diamond'),
@@ -145,6 +159,34 @@ def display_filter_label(band_name: str | None) -> str:
     if band_name:
         return band_name.strip()
     return '?'
+
+
+def telescope_display_name(
+    instrument_name: str | None = None,
+    telescope_name: str | None = None,
+) -> str:
+    """Short telescope family label for plot legends (e.g. ZTF-Cam -> ZTF)."""
+    for candidate in (telescope_name, instrument_name):
+        if not candidate or not str(candidate).strip():
+            continue
+        lower = str(candidate).strip().lower()
+        for patterns, label in TELESCOPE_SHORT_LABELS:
+            if any(pat in lower for pat in patterns):
+                return label
+        return str(candidate).strip()
+    return 'Unknown'
+
+
+def plot_legend_label(
+    band_name: str | None,
+    *,
+    instrument_name: str | None = None,
+    telescope_name: str | None = None,
+) -> str:
+    """Legend text: telescope + short filter (e.g. 'ZTF r')."""
+    tel = telescope_display_name(instrument_name, telescope_name)
+    filt = display_filter_label(band_name)
+    return f'{tel} {filt}'
 
 
 def filter_color_groups_for_display() -> list[dict]:

--- a/YSE_App/common/filter_display.py
+++ b/YSE_App/common/filter_display.py
@@ -137,6 +137,16 @@ def telescope_display_symbol(
     return 'triangle'
 
 
+def display_filter_label(band_name: str | None) -> str:
+    """Short plot label (e.g. r-ZTF -> r). DB band name unchanged."""
+    canonical = normalize_filter_name(band_name)
+    if canonical:
+        return canonical
+    if band_name:
+        return band_name.strip()
+    return '?'
+
+
 def filter_color_groups_for_display() -> list[dict]:
     """Human-readable color groups for docs / chat (filter family -> example names)."""
     groups = []

--- a/YSE_App/common/magnitude_format.py
+++ b/YSE_App/common/magnitude_format.py
@@ -1,0 +1,27 @@
+"""Format magnitudes and uncertainties for UI display."""
+
+from __future__ import annotations
+
+
+def format_magnitude(value) -> str:
+    """Two decimal places for magnitudes (e.g. 18.32 not 18.3248572)."""
+    if value is None or value == '':
+        return '-'
+    try:
+        return f'{float(value):.2f}'
+    except (TypeError, ValueError):
+        return str(value)
+
+
+def format_magnitude_with_error(mag, mag_err=None) -> str:
+    """Format mag ± err when an uncertainty is present."""
+    mag_str = format_magnitude(mag)
+    if mag_err is None or mag_err == '':
+        return mag_str
+    try:
+        err = float(mag_err)
+    except (TypeError, ValueError):
+        return mag_str
+    if err <= 0:
+        return mag_str
+    return f'{mag_str} ± {err:.2f}'

--- a/YSE_App/table_utils.py
+++ b/YSE_App/table_utils.py
@@ -19,6 +19,7 @@ from matplotlib.figure import Figure
 from matplotlib.dates import DateFormatter
 from matplotlib import rcParams
 from django.db.models.expressions import RawSQL
+from .common.magnitude_format import format_magnitude
 rcParams['figure.figsize'] = (7,7)
 
 
@@ -27,6 +28,13 @@ def stable_order_by(queryset, field, is_descending):
     if is_descending:
         return queryset.order_by(f'-{field}', '-pk')
     return queryset.order_by(field, 'pk')
+
+
+class MagnitudeColumn(tables.Column):
+    """Dashboard magnitude column with two decimal places."""
+
+    def render(self, value):
+        return format_magnitude(value)
 
 
 class TransientTable(tables.Table):
@@ -39,7 +47,7 @@ class TransientTable(tables.Table):
                                verbose_name='DEC',orderable=True,order_by='dec')
     disc_date_string = tables.Column(accessor='disc_date_string',
                                      verbose_name='Disc. Date',orderable=True,order_by='disc_date')
-    recent_mag = tables.Column(accessor='recent_mag',
+    recent_mag = MagnitudeColumn(accessor='recent_mag',
                                verbose_name='Last Mag',orderable=True)
     recent_magdate = tables.Column(accessor='recent_magdate',
                                verbose_name='Last Obs. Date',orderable=True)
@@ -153,7 +161,7 @@ class FieldTransientTable(tables.Table):
                                verbose_name='DEC',orderable=True,order_by='dec')
     disc_date_string = tables.Column(accessor='disc_date_string',
                                      verbose_name='Disc. Date',orderable=True,order_by='disc_date')
-    recent_mag = tables.Column(accessor='recent_mag',
+    recent_mag = MagnitudeColumn(accessor='recent_mag',
                                verbose_name='Last Mag',orderable=True)
     recent_magdate = tables.Column(accessor='recent_magdate',
                                verbose_name='Last Obs. Date',orderable=True)
@@ -275,7 +283,7 @@ class AdjustFieldTransientTable(tables.Table):
                                verbose_name='DEC',orderable=True,order_by='dec')
     disc_date_string = tables.Column(accessor='disc_date_string',
                                      verbose_name='Disc. Date',orderable=True,order_by='disc_date')
-    recent_mag = tables.Column(accessor='recent_mag',
+    recent_mag = MagnitudeColumn(accessor='recent_mag',
                                verbose_name='Last Mag',orderable=True)
     recent_magdate = tables.Column(accessor='recent_magdate',
                                verbose_name='Last Obs. Date',orderable=True)
@@ -398,7 +406,7 @@ class YSETransientTable(tables.Table):
                                verbose_name='DEC',orderable=True,order_by='dec')
     disc_date_string = tables.Column(accessor='disc_date_string',
                                      verbose_name='Disc. Date',orderable=True,order_by='disc_date')
-    recent_mag = tables.Column(accessor='recent_mag',
+    recent_mag = MagnitudeColumn(accessor='recent_mag',
                                verbose_name='Last Mag',orderable=True)
     recent_magdate = tables.Column(accessor='recent_magdate',
                                verbose_name='Last Obs. Date',orderable=True)
@@ -559,7 +567,7 @@ class YSEFullTransientTable(tables.Table):
                                verbose_name='DEC',orderable=True,order_by='dec')
     disc_date_string = tables.Column(accessor='disc_date_string',
                                      verbose_name='Disc. Date',orderable=True,order_by='disc_date')
-    recent_mag = tables.Column(accessor='recent_mag',
+    recent_mag = MagnitudeColumn(accessor='recent_mag',
                                verbose_name='Last Mag',orderable=True)
     recent_magdate = tables.Column(accessor='recent_magdate',
                                verbose_name='Last Obs. Date',orderable=True)
@@ -708,7 +716,7 @@ class YSERisingTransientTable(tables.Table):
                                verbose_name='DEC',orderable=True,order_by='dec')
     disc_date_string = tables.Column(accessor='disc_date_string',
                                      verbose_name='Disc. Date',orderable=True,order_by='disc_date')
-    recent_mag = tables.Column(accessor='recent_mag',
+    recent_mag = MagnitudeColumn(accessor='recent_mag',
                                verbose_name='Last Mag',orderable=True)
     recent_magdate = tables.Column(accessor='recent_magdate',
                                verbose_name='Last Obs. Date',orderable=True)
@@ -868,7 +876,7 @@ class NewTransientTable(tables.Table):
                                verbose_name='DEC',orderable=True,order_by='dec')
     disc_date_string = tables.Column(accessor='disc_date_string',
                                      verbose_name='Disc. Date',orderable=True,order_by='disc_date')
-    recent_mag = tables.Column(accessor='recent_mag',
+    recent_mag = MagnitudeColumn(accessor='recent_mag',
                                verbose_name='Last Mag',orderable=True)
     recent_magdate = tables.Column(accessor='recent_magdate',
                                verbose_name='Last Obs. Date',orderable=True)

--- a/YSE_App/templates/YSE_App/personaldashboard.html
+++ b/YSE_App/templates/YSE_App/personaldashboard.html
@@ -163,9 +163,18 @@
 <script type='text/javascript'>
 {% if personal_dashboard_defer %}
 $(document).ready(function() {
+  function sectionUrl($slot) {
+    var url = $slot.data('url');
+    var search = window.location.search;
+    if (search && search.length > 1) {
+      url += (url.indexOf('?') >= 0 ? '&' : '?') + search.substring(1);
+    }
+    return url;
+  }
+
   $('.pdash-section-loading').each(function() {
     var $slot = $(this);
-    $.get($slot.data('url'), function(html) {
+    $.get(sectionUrl($slot), function(html) {
       $slot.replaceWith(html);
     }).fail(function() {
       $slot.html('<p class="text-danger">Failed to load this section.</p>');

--- a/YSE_App/templates/YSE_App/transient_detail.html
+++ b/YSE_App/templates/YSE_App/transient_detail.html
@@ -1780,19 +1780,46 @@
 
         $.get("{% url 'get_hst_status' transient.id %}").done(function(json) {
             if (!json.has_data) {
-                $("#hst_tab_header").prepend("No ");
+                $("#hst_tab_header").text("No HST");
             }
         });
         $.get("{% url 'get_chandra_status' transient.id %}").done(function(json) {
             if (!json.has_data) {
-                $("#chandra_tab_header").prepend("No ");
+                $("#chandra_tab_header").text("No Chandra");
             }
         });
 
-        // Background: follow-up phased load + summary spectrum dropdown tools.
+        // Background: preload deferred tab fragments for faster tab switches.
         setTimeout(function() {
             loadFollowupTabPhased();
             loadSummarySpectraTools();
+            loadTransientDetailFragment(
+                'resources',
+                "{% url 'transient_detail_resources_fragment' transient.id %}",
+                $('#resources_deferred_tables')
+            );
+            loadTransientDetailFragment(
+                'photometry',
+                "{% url 'transient_detail_photometry_fragment' transient.id %}",
+                $('#photometry_deferred_tables')
+            );
+            loadTransientDetailFragment(
+                'comments',
+                "{% url 'transient_detail_comments_fragment' transient.id %}",
+                $('#comments_list_slot')
+            );
+            loadTransientDetailFragment(
+                'spectra_tab',
+                "{% url 'transient_detail_spectra_tab_fragment' transient.id %}",
+                $('#spectra_tab_content')
+            );
+            {% if has_gw_candidate_tag %}
+            loadTransientDetailFragment(
+                'gw',
+                "{% url 'transient_detail_gw_fragment' transient.id %}",
+                $('#gw_tab_content')
+            );
+            {% endif %}
         }, 0);
 {% else %}
         loadHstImages();

--- a/YSE_App/templates/YSE_App/transient_detail.html
+++ b/YSE_App/templates/YSE_App/transient_detail.html
@@ -237,6 +237,32 @@
             setPlotHtml("#lcplot", html,
                 '<p class="text-muted yse-plot-empty">No photometry to plot.</p>');
         });
+{% if transient_detail_defer %}
+        function yseUpdateArchiveTabLabel($tab, url, emptyLabel) {
+            if (!$tab.length) {
+                return;
+            }
+            $.ajax({ url: url, dataType: 'json', timeout: 10000 })
+                .done(function(json) {
+                    if (!json || !json.has_data) {
+                        $tab.text(emptyLabel);
+                    }
+                })
+                .fail(function() {
+                    $tab.text(emptyLabel);
+                });
+        }
+        yseUpdateArchiveTabLabel(
+            $("#hst_tab_header"),
+            "{% url 'get_hst_status' transient.id %}",
+            "No HST"
+        );
+        yseUpdateArchiveTabLabel(
+            $("#chandra_tab_header"),
+            "{% url 'get_chandra_status' transient.id %}",
+            "No Chandra"
+        );
+{% endif %}
         $.get("{% url 'get_ps1_image' transient.id %}").done(function (json) {
             var rows = $("#ps1_image");
             var htmltext;
@@ -850,28 +876,38 @@
             //date_picker.setDate(null)
             //$('#obs_date').val(date_picker.getDate())
 
-            // Initialize daterange
+            // Initialize daterange (follow-up forms may load via deferred fragment)
             if ($('#follow_date_range').length) {
-                fdr_picker = $('#follow_date_range').data('daterangepicker')
-                $('#valid_start').val(fdr_picker.startDate.format("YYYY-MM-DD HH:mm:00"))
-                $('#valid_stop').val(fdr_picker.endDate.format("YYYY-MM-DD HH:mm:00"))
+                fdr_picker = $('#follow_date_range').data('daterangepicker');
+                if (fdr_picker) {
+                    $('#valid_start').val(fdr_picker.startDate.format("YYYY-MM-DD HH:mm:00"));
+                    $('#valid_stop').val(fdr_picker.endDate.format("YYYY-MM-DD HH:mm:00"));
+                }
             }
 
-            // Intialize Desired Obs Date. Don't initialize Actual Obs Date...
-            otd_picker = $('#obs_task_desired_picker').data('daterangepicker')
-            $('#desired_obs_date').val(otd_picker.startDate.format("YYYY-MM-DD HH:mm:00"))
+            if ($('#obs_task_desired_picker').length) {
+                otd_picker = $('#obs_task_desired_picker').data('daterangepicker');
+                if (otd_picker) {
+                    $('#desired_obs_date').val(otd_picker.startDate.format("YYYY-MM-DD HH:mm:00"));
+                }
+            }
 
-            //Respond to daterange change events
-            $('#obs_task_desired_picker').on('apply.daterangepicker', function(ev, picker) {
-                $('#desired_obs_date').val(picker.startDate.format("YYYY-MM-DD HH:mm:00"))
-            });
-            $('#obs_task_actual_picker').on('apply.daterangepicker', function(ev, picker) {
-                $('#actual_obs_date').val(picker.startDate.format("YYYY-MM-DD HH:mm:00"))
-            });
-            $('#follow_date_range').on('apply.daterangepicker', function(ev, picker) {
-                $('#valid_start').val(picker.startDate.format("YYYY-MM-DD HH:mm:00"))
-                $('#valid_stop').val(picker.endDate.format("YYYY-MM-DD HH:mm:00"))
-            });
+            if ($('#obs_task_desired_picker').length) {
+                $('#obs_task_desired_picker').on('apply.daterangepicker', function(ev, picker) {
+                    $('#desired_obs_date').val(picker.startDate.format("YYYY-MM-DD HH:mm:00"));
+                });
+            }
+            if ($('#obs_task_actual_picker').length) {
+                $('#obs_task_actual_picker').on('apply.daterangepicker', function(ev, picker) {
+                    $('#actual_obs_date').val(picker.startDate.format("YYYY-MM-DD HH:mm:00"));
+                });
+            }
+            if ($('#follow_date_range').length) {
+                $('#follow_date_range').on('apply.daterangepicker', function(ev, picker) {
+                    $('#valid_start').val(picker.startDate.format("YYYY-MM-DD HH:mm:00"));
+                    $('#valid_stop').val(picker.endDate.format("YYYY-MM-DD HH:mm:00"));
+                });
+            }
             $('#spec_obs_date').on('apply.datetimepicker', function(ev, picker) {
                 $('#obs_date').getDate()
             });
@@ -1681,6 +1717,9 @@
         var followupPhasedLoadPromise = null;
 
         function loadTransientDetailFragment(key, url, $container) {
+            if (!$container.length) {
+                return $.Deferred().resolve().promise();
+            }
             if (transientDetailFragmentsLoaded[key]) {
                 return $.Deferred().resolve().promise();
             }
@@ -1778,17 +1817,6 @@
             );
         }
 
-        $.get("{% url 'get_hst_status' transient.id %}").done(function(json) {
-            if (!json.has_data) {
-                $("#hst_tab_header").text("No HST");
-            }
-        });
-        $.get("{% url 'get_chandra_status' transient.id %}").done(function(json) {
-            if (!json.has_data) {
-                $("#chandra_tab_header").text("No Chandra");
-            }
-        });
-
         // Background: preload deferred tab fragments for faster tab switches.
         setTimeout(function() {
             loadFollowupTabPhased();
@@ -1802,11 +1830,6 @@
                 'photometry',
                 "{% url 'transient_detail_photometry_fragment' transient.id %}",
                 $('#photometry_deferred_tables')
-            );
-            loadTransientDetailFragment(
-                'comments',
-                "{% url 'transient_detail_comments_fragment' transient.id %}",
-                $('#comments_list_slot')
             );
             loadTransientDetailFragment(
                 'spectra_tab',

--- a/YSE_App/templates/YSE_App/transient_detail.html
+++ b/YSE_App/templates/YSE_App/transient_detail.html
@@ -30,6 +30,9 @@
 
     <div class="row">
         <div class="col-xs-12">
+            {% if transient_detail_defer %}
+            <input type="hidden" id="transient_pk" value="{{ transient.id }}"/>
+            {% endif %}
             <div class="nav-tabs-custom yse-page-transient-summary">
                 <ul class="nav nav-tabs">
                     <li class="active"><a href="#summary_tab" data-toggle="tab">Summary</a></li>
@@ -262,6 +265,133 @@
             "{% url 'get_chandra_status' transient.id %}",
             "No Chandra"
         );
+
+        var yseDetailFragmentsLoaded = {};
+        function yseLoadDetailFragment(key, url, selector) {
+            var $c = $(selector);
+            var deferred = $.Deferred();
+            if (!$c.length) {
+                deferred.resolve();
+                return deferred.promise();
+            }
+            if (yseDetailFragmentsLoaded[key]) {
+                deferred.resolve();
+                return deferred.promise();
+            }
+            yseDetailFragmentsLoaded[key] = true;
+            $c.html('<p class="text-muted"><i class="fa fa-spinner fa-spin"></i> Loading…</p>');
+            $.get(url).done(function(html) {
+                $c.html(html);
+                if (key === 'followup_requests' && $.fn.boxWidget) {
+                    $('.followupbox').boxWidget();
+                }
+                if (key === 'followup_rest' && window.yseInitFollowupTabWidgets) {
+                    window.yseInitFollowupTabWidgets();
+                }
+                deferred.resolve();
+            }).fail(function() {
+                yseDetailFragmentsLoaded[key] = false;
+                $c.html('<p class="text-danger">Failed to load this section.</p>');
+                deferred.reject();
+            });
+            return deferred.promise();
+        }
+
+        var yseFollowupLoadPromise = null;
+        function yseLoadFollowupPhased() {
+            if (yseFollowupLoadPromise) {
+                return yseFollowupLoadPromise;
+            }
+            yseFollowupLoadPromise = yseLoadDetailFragment(
+                'followup_requests',
+                "{% url 'transient_detail_followup_fragment' transient.id %}",
+                '#followup_container'
+            ).then(function() {
+                return yseLoadDetailFragment(
+                    'followup_classical',
+                    "{% url 'transient_detail_followup_classical_fragment' transient.id %}",
+                    '#followup_classical_slot'
+                );
+            }).then(function() {
+                return yseLoadDetailFragment(
+                    'followup_rest',
+                    "{% url 'transient_detail_followup_rest_fragment' transient.id %}",
+                    '#followup_rest_slot'
+                );
+            });
+            return yseFollowupLoadPromise;
+        }
+
+        var yseHstImagesLoaded = false;
+        var yseChandraImagesLoaded = false;
+        $(function() {
+            $('a[data-toggle="tab"]').on('shown.bs.tab', function(e) {
+                var target = $(e.target).attr('href');
+                if (target === '#followup_tab') {
+                    yseLoadFollowupPhased();
+                } else if (target === '#resources_tab') {
+                    yseLoadDetailFragment(
+                        'resources',
+                        "{% url 'transient_detail_resources_fragment' transient.id %}",
+                        '#resources_deferred_tables'
+                    );
+                } else if (target === '#photometry_tab') {
+                    yseLoadDetailFragment(
+                        'photometry',
+                        "{% url 'transient_detail_photometry_fragment' transient.id %}",
+                        '#photometry_deferred_tables'
+                    );
+                } else if (target === '#hst_tab' && !yseHstImagesLoaded) {
+                    yseHstImagesLoaded = true;
+                    if (window.yseLoadHstImages) {
+                        window.yseLoadHstImages();
+                    }
+                } else if (target === '#chandra_tab' && !yseChandraImagesLoaded) {
+                    yseChandraImagesLoaded = true;
+                    if (window.yseLoadChandraImages) {
+                        window.yseLoadChandraImages();
+                    }
+                } else if (target === '#spectra_tab') {
+                    yseLoadDetailFragment(
+                        'spectra_tab',
+                        "{% url 'transient_detail_spectra_tab_fragment' transient.id %}",
+                        '#spectra_tab_content'
+                    );
+                } else if (target === '#gw_tab') {
+                    yseLoadDetailFragment(
+                        'gw',
+                        "{% url 'transient_detail_gw_fragment' transient.id %}",
+                        '#gw_tab_content'
+                    );
+                }
+            });
+
+            setTimeout(function() {
+                yseLoadFollowupPhased();
+                yseLoadDetailFragment(
+                    'resources',
+                    "{% url 'transient_detail_resources_fragment' transient.id %}",
+                    '#resources_deferred_tables'
+                );
+                yseLoadDetailFragment(
+                    'photometry',
+                    "{% url 'transient_detail_photometry_fragment' transient.id %}",
+                    '#photometry_deferred_tables'
+                );
+                yseLoadDetailFragment(
+                    'spectra_tab',
+                    "{% url 'transient_detail_spectra_tab_fragment' transient.id %}",
+                    '#spectra_tab_content'
+                );
+                {% if has_gw_candidate_tag %}
+                yseLoadDetailFragment(
+                    'gw',
+                    "{% url 'transient_detail_gw_fragment' transient.id %}",
+                    '#gw_tab_content'
+                );
+                {% endif %}
+            }, 0);
+        });
 {% endif %}
         $.get("{% url 'get_ps1_image' transient.id %}").done(function (json) {
             var rows = $("#ps1_image");
@@ -331,7 +461,11 @@
             // add autocomplete form, no more drag/drop
             function add_tags(){
                 var tags_list = document.getElementById('tags_datalist');
-                var tag_id = document.querySelector("#tags option[value='"+tags_list.value+"']").getAttribute('data-tag_id')
+                var option = document.querySelector("#tags option[value='"+tags_list.value+"']");
+                if (!option) {
+                    return;
+                }
+                var tag_id = option.getAttribute('data-tag_id')
                 //var tag_id = tags.value;
                 //alert("Hi!"+tags_list.value);
                 var transient_id = $('#transient_pk').val();
@@ -605,14 +739,16 @@
 
             })
 
-            $('#example1').DataTable({
-                  'paging'      : false,
-                  'lengthChange': false,
-                  'searching'   : false,
-                  'ordering'    : false,
-                  'info'        : false,
-                  'autoWidth'   : false
-                })
+            if ($('#example1').length) {
+                $('#example1').DataTable({
+                      'paging'      : false,
+                      'lengthChange': false,
+                      'searching'   : false,
+                      'ordering'    : false,
+                      'info'        : false,
+                      'autoWidth'   : false
+                    });
+            }
             // $('#example2').DataTable({
             //   'paging'      : true,
             //   'lengthChange': false,
@@ -665,62 +801,7 @@
             //	}
             //});
 
-            $('#obs_task_desired_picker').daterangepicker({
-                timePicker24Hour: true,
-                timePicker: true,
-                timePickerIncrement: 1,
-                singleDatePicker: true,
-                format: 'MM/DD/YYYY HH:mm',
-                locale: {
-                    format: 'MM/DD/YYYY HH:mm'
-                }
-            });
-
-            $('#obs_task_actual_picker').daterangepicker({
-                timePicker24Hour: true,
-                timePicker: true,
-                timePickerIncrement: 1,
-                singleDatePicker: true,
-                format: 'MM/DD/YYYY HH:mm',
-                locale: {
-                    format: 'MM/DD/YYYY HH:mm'
-                }
-            });
-            // Clear initial value
-            $('#obs_task_actual_picker').val('');
-
-            // too resource
-            $('#too_resource_date_range').daterangepicker({
-                timePicker24Hour: true,
-                timePicker: true,
-                timePickerIncrement: 1,
-                format: 'YYYY-MM-DD HH:mm',
-                locale: {
-                  format: 'YYYY-MM-DD HH:mm'
-                }
-            });
-
-            // Initialize daterange
-              fdr_picker = $('#too_resource_date_range').data('daterangepicker')
-              $('#begin_date_valid').val(fdr_picker.startDate.format("YYYY-MM-DD HH:mm:00"))
-              $('#end_date_valid').val(fdr_picker.endDate.format("YYYY-MM-DD HH:mm:00"))
-              $('#too_resource_date_range').on('apply.daterangepicker', function(ev, picker) {
-                $('#begin_date_valid').val(picker.startDate.format("YYYY-MM-DD HH:mm:00"))
-                $('#end_date_valid').val(picker.endDate.format("YYYY-MM-DD HH:mm:00"))
-              });
-
-            // classical resource
-            $('#observing_date').datepicker({
-              timePicker24Hour: true,
-              timePicker: true,
-              timePickerIncrement: 1,
-              format: 'mm/dd/yyyy',
-              //todayBtn: "linked",
-              locale: {
-                  format: 'mm/dd/yyyy'
-              }
-            });
-
+            // Follow-up form widgets load with deferred fragments (see initFollowupTabWidgets).
       // classical resource
       $('#add_classical_resource').on('submit', function(event){
         event.preventDefault();
@@ -867,9 +948,70 @@
                         format: 'MM/DD/YYYY HH:mm'
                     }
                 });
+                $('#follow_date_range').on('apply.daterangepicker', function(ev, picker) {
+                    $('#valid_start').val(picker.startDate.format("YYYY-MM-DD HH:mm:00"));
+                    $('#valid_stop').val(picker.endDate.format("YYYY-MM-DD HH:mm:00"));
+                });
+                var fdr_picker = $('#follow_date_range').data('daterangepicker');
+                if (fdr_picker) {
+                    $('#valid_start').val(fdr_picker.startDate.format("YYYY-MM-DD HH:mm:00"));
+                    $('#valid_stop').val(fdr_picker.endDate.format("YYYY-MM-DD HH:mm:00"));
+                }
+            }
+            if ($('#obs_task_desired_picker').length && !$('#obs_task_desired_picker').data('daterangepicker')) {
+                $('#obs_task_desired_picker').daterangepicker({
+                    timePicker24Hour: true,
+                    timePicker: true,
+                    timePickerIncrement: 1,
+                    singleDatePicker: true,
+                    format: 'MM/DD/YYYY HH:mm',
+                    locale: { format: 'MM/DD/YYYY HH:mm' }
+                });
+                $('#obs_task_desired_picker').on('apply.daterangepicker', function(ev, picker) {
+                    $('#desired_obs_date').val(picker.startDate.format("YYYY-MM-DD HH:mm:00"));
+                });
+            }
+            if ($('#obs_task_actual_picker').length && !$('#obs_task_actual_picker').data('daterangepicker')) {
+                $('#obs_task_actual_picker').daterangepicker({
+                    timePicker24Hour: true,
+                    timePicker: true,
+                    timePickerIncrement: 1,
+                    singleDatePicker: true,
+                    format: 'MM/DD/YYYY HH:mm',
+                    locale: { format: 'MM/DD/YYYY HH:mm' }
+                });
+                $('#obs_task_actual_picker').val('');
+                $('#obs_task_actual_picker').on('apply.daterangepicker', function(ev, picker) {
+                    $('#actual_obs_date').val(picker.startDate.format("YYYY-MM-DD HH:mm:00"));
+                });
+            }
+            if ($('#too_resource_date_range').length && !$('#too_resource_date_range').data('daterangepicker')) {
+                $('#too_resource_date_range').daterangepicker({
+                    timePicker24Hour: true,
+                    timePicker: true,
+                    timePickerIncrement: 1,
+                    format: 'YYYY-MM-DD HH:mm',
+                    locale: { format: 'YYYY-MM-DD HH:mm' }
+                });
+                $('#too_resource_date_range').on('apply.daterangepicker', function(ev, picker) {
+                    $('#begin_date_valid').val(picker.startDate.format("YYYY-MM-DD HH:mm:00"));
+                    $('#end_date_valid').val(picker.endDate.format("YYYY-MM-DD HH:mm:00"));
+                });
+                var too_picker = $('#too_resource_date_range').data('daterangepicker');
+                if (too_picker) {
+                    $('#begin_date_valid').val(too_picker.startDate.format("YYYY-MM-DD HH:mm:00"));
+                    $('#end_date_valid').val(too_picker.endDate.format("YYYY-MM-DD HH:mm:00"));
+                }
+            }
+            if ($('#observing_date').length && !$('#observing_date').data('datepicker')) {
+                $('#observing_date').datepicker({
+                    format: 'mm/dd/yyyy',
+                    locale: { format: 'mm/dd/yyyy' }
+                });
             }
             initAutomatedSpectrumDateRange();
         }
+        window.yseInitFollowupTabWidgets = initFollowupTabWidgets;
 
             // Initialize date
             //date_picker = $('#spec_obs_date').data('datetimepicker')
@@ -977,8 +1119,8 @@
             })();
 
 
-            // Submit post on submit
-            $('#add_transient_followup').on('submit', function(event){
+            // Submit post on submit (delegated — follow-up form may load via fragment)
+            $(document).on('submit', '#add_transient_followup', function(event){
                 event.preventDefault();
                 add_transient_followup();
             });
@@ -1711,140 +1853,10 @@
                 $(rows_exp).prepend(json.totalexp+"s ")
             });
         }
+        window.yseLoadHstImages = loadHstImages;
+        window.yseLoadChandraImages = loadChandraImages;
 
-{% if transient_detail_defer %}
-        var transientDetailFragmentsLoaded = {};
-        var followupPhasedLoadPromise = null;
-
-        function loadTransientDetailFragment(key, url, $container) {
-            if (!$container.length) {
-                return $.Deferred().resolve().promise();
-            }
-            if (transientDetailFragmentsLoaded[key]) {
-                return $.Deferred().resolve().promise();
-            }
-            transientDetailFragmentsLoaded[key] = true;
-            $container.html('<p class="text-muted"><i class="fa fa-spinner fa-spin"></i> Loading…</p>');
-            return $.get(url).done(function(html) {
-                $container.html(html);
-                if (key === 'followup_requests') {
-                    $('.followupbox').boxWidget();
-                }
-                if (key === 'followup_rest') {
-                    initFollowupTabWidgets();
-                }
-            }).fail(function() {
-                $container.html('<p class="text-danger">Failed to load this section.</p>');
-                transientDetailFragmentsLoaded[key] = false;
-            });
-        }
-
-        function loadFollowupTabPhased() {
-            if (followupPhasedLoadPromise) {
-                return followupPhasedLoadPromise;
-            }
-            // Phase 1: past requests; 2: classical; 3: forms + ToO + automated (classical before ToO).
-            followupPhasedLoadPromise = loadTransientDetailFragment(
-                'followup_requests',
-                "{% url 'transient_detail_followup_fragment' transient.id %}",
-                $('#followup_container')
-            ).then(function() {
-                return loadTransientDetailFragment(
-                    'followup_classical',
-                    "{% url 'transient_detail_followup_classical_fragment' transient.id %}",
-                    $('#followup_classical_slot')
-                );
-            }).then(function() {
-                return loadTransientDetailFragment(
-                    'followup_rest',
-                    "{% url 'transient_detail_followup_rest_fragment' transient.id %}",
-                    $('#followup_rest_slot')
-                );
-            });
-            return followupPhasedLoadPromise;
-        }
-
-        var hstImagesLoaded = false;
-        var chandraImagesLoaded = false;
-        $('a[data-toggle="tab"]').on('shown.bs.tab', function(e) {
-            var target = $(e.target).attr('href');
-            if (target === '#followup_tab') {
-                loadFollowupTabPhased();
-            } else if (target === '#resources_tab') {
-                loadTransientDetailFragment(
-                    'resources',
-                    "{% url 'transient_detail_resources_fragment' transient.id %}",
-                    $('#resources_deferred_tables')
-                );
-            } else if (target === '#photometry_tab') {
-                loadTransientDetailFragment(
-                    'photometry',
-                    "{% url 'transient_detail_photometry_fragment' transient.id %}",
-                    $('#photometry_deferred_tables')
-                );
-            } else if (target === '#hst_tab' && !hstImagesLoaded) {
-                hstImagesLoaded = true;
-                loadHstImages();
-            } else if (target === '#chandra_tab' && !chandraImagesLoaded) {
-                chandraImagesLoaded = true;
-                loadChandraImages();
-            } else if (target === '#comments_tab') {
-                loadTransientDetailFragment(
-                    'comments',
-                    "{% url 'transient_detail_comments_fragment' transient.id %}",
-                    $('#comments_list_slot')
-                );
-            } else if (target === '#gw_tab') {
-                loadTransientDetailFragment(
-                    'gw',
-                    "{% url 'transient_detail_gw_fragment' transient.id %}",
-                    $('#gw_tab_content')
-                );
-            } else if (target === '#spectra_tab') {
-                loadTransientDetailFragment(
-                    'spectra_tab',
-                    "{% url 'transient_detail_spectra_tab_fragment' transient.id %}",
-                    $('#spectra_tab_content')
-                );
-            }
-        });
-
-        function loadSummarySpectraTools() {
-            return loadTransientDetailFragment(
-                'summary_spectra_tools',
-                "{% url 'transient_detail_summary_spectra_tools_fragment' transient.id %}",
-                $('#summary_spectrum_tools_slot')
-            );
-        }
-
-        // Background: preload deferred tab fragments for faster tab switches.
-        setTimeout(function() {
-            loadFollowupTabPhased();
-            loadSummarySpectraTools();
-            loadTransientDetailFragment(
-                'resources',
-                "{% url 'transient_detail_resources_fragment' transient.id %}",
-                $('#resources_deferred_tables')
-            );
-            loadTransientDetailFragment(
-                'photometry',
-                "{% url 'transient_detail_photometry_fragment' transient.id %}",
-                $('#photometry_deferred_tables')
-            );
-            loadTransientDetailFragment(
-                'spectra_tab',
-                "{% url 'transient_detail_spectra_tab_fragment' transient.id %}",
-                $('#spectra_tab_content')
-            );
-            {% if has_gw_candidate_tag %}
-            loadTransientDetailFragment(
-                'gw',
-                "{% url 'transient_detail_gw_fragment' transient.id %}",
-                $('#gw_tab_content')
-            );
-            {% endif %}
-        }, 0);
-{% else %}
+{% if not transient_detail_defer %}
         loadHstImages();
         loadChandraImages();
 {% endif %}

--- a/YSE_App/templatetags/transient_detail_extras.py
+++ b/YSE_App/templatetags/transient_detail_extras.py
@@ -7,6 +7,7 @@ from astropy.time import Time
 import astropy.units as u
 from django import template
 from ..models import *
+from YSE_App.common.magnitude_format import format_magnitude
 from astropy.cosmology import FlatLambdaCDM
 cosmo = FlatLambdaCDM(70,0.3)
 
@@ -41,6 +42,16 @@ def galcoordsb(coordstring):
 
 	sc = SkyCoord('%s %s'%(coordstring[0],coordstring[1]),frame="fk5",unit=(u.hourangle,u.deg))
 	return '%.7f'%sc.galactic.b.value
+
+
+@register.filter(name='format_mag')
+def format_mag(value):
+    return format_magnitude(value)
+
+
+@register.filter(name='format_mag_err')
+def format_mag_err(value):
+    return format_magnitude(value)
 
 
 @register.filter(name='replace_space')

--- a/YSE_App/tests/test_ui_regressions.py
+++ b/YSE_App/tests/test_ui_regressions.py
@@ -10,6 +10,7 @@ from explorer.models import Query
 
 from YSE_App.common.filter_display import (
     band_display_color,
+    display_filter_label,
     normalize_filter_name,
     telescope_display_symbol,
 )
@@ -47,6 +48,11 @@ class FilterDisplayTests(TestCase):
     def test_g_atlas_cyan_maps_to_green(self):
         self.assertEqual(normalize_filter_name('cyan-ATLAS'), 'g')
         self.assertEqual(band_display_color('cyan-ATLAS', None), '#008000')
+
+    def test_display_filter_label_shortens_instrument_suffix(self):
+        self.assertEqual(display_filter_label('r-ZTF'), 'r')
+        self.assertEqual(display_filter_label('g-WFT'), 'g')
+        self.assertEqual(display_filter_label('r'), 'r')
 
 
 class MagnitudeFormatTests(TestCase):

--- a/YSE_App/tests/test_ui_regressions.py
+++ b/YSE_App/tests/test_ui_regressions.py
@@ -12,6 +12,8 @@ from YSE_App.common.filter_display import (
     band_display_color,
     display_filter_label,
     normalize_filter_name,
+    plot_legend_label,
+    telescope_display_name,
     telescope_display_symbol,
 )
 from YSE_App.common.magnitude_format import format_magnitude, format_magnitude_with_error
@@ -53,6 +55,21 @@ class FilterDisplayTests(TestCase):
         self.assertEqual(display_filter_label('r-ZTF'), 'r')
         self.assertEqual(display_filter_label('g-WFT'), 'g')
         self.assertEqual(display_filter_label('r'), 'r')
+
+    def test_telescope_display_name_shortens_instrument(self):
+        self.assertEqual(telescope_display_name('ZTF-Cam', 'ZTF'), 'ZTF')
+        self.assertEqual(telescope_display_name('ZTF-Cam', None), 'ZTF')
+        self.assertEqual(telescope_display_name(None, '1m-SWOPE'), 'Swope')
+
+    def test_plot_legend_label_telescope_and_filter_separate(self):
+        self.assertEqual(
+            plot_legend_label('r-ZTF', instrument_name='ZTF-Cam', telescope_name='ZTF'),
+            'ZTF r',
+        )
+        self.assertEqual(
+            plot_legend_label('g-WFT', instrument_name='WFT', telescope_name=None),
+            'WFT g',
+        )
 
 
 class MagnitudeFormatTests(TestCase):

--- a/YSE_App/tests/test_ui_regressions.py
+++ b/YSE_App/tests/test_ui_regressions.py
@@ -1,0 +1,147 @@
+"""Regression tests for post-merge UI fixes (filter colors, pagination, magnitudes)."""
+
+import os
+import unittest
+from unittest import mock
+
+from django.core.cache import cache
+from django.test import Client, TestCase
+from explorer.models import Query
+
+from YSE_App.common.filter_display import (
+    band_display_color,
+    normalize_filter_name,
+    telescope_display_symbol,
+)
+from YSE_App.common.magnitude_format import format_magnitude, format_magnitude_with_error
+from YSE_App.models import Transient, UserQuery
+from YSE_App.table_utils import MagnitudeColumn, annotate_dashboard_transient_fields
+from YSE_App.tests.fixtures_minimal import (
+    attach_synthetic_photometry,
+    audit_fields,
+    create_minimal_transient,
+    create_test_user,
+)
+from YSE_App.views import QUERY_CACHE_VERSION
+
+
+class FilterDisplayTests(TestCase):
+    def test_normalize_r_family_filters(self):
+        self.assertEqual(normalize_filter_name('r-ZTF'), 'r')
+        self.assertEqual(normalize_filter_name('r-WFT'), 'r')
+        self.assertEqual(normalize_filter_name('r'), 'r')
+        self.assertEqual(normalize_filter_name('R-Cousins'), 'r')
+
+    def test_r_family_shares_swope_red(self):
+        swope_r = band_display_color('r', '#DC143C')
+        ztf_r = band_display_color('r-ZTF', None)
+        wft_r = band_display_color('r-WFT', None)
+        self.assertEqual(swope_r, ztf_r)
+        self.assertEqual(swope_r, wft_r)
+        self.assertEqual(swope_r, '#DC143C')
+
+    def test_telescope_symbol_groups_ztf(self):
+        self.assertEqual(telescope_display_symbol('ZTF-Cam'), 'diamond')
+        self.assertEqual(telescope_display_symbol('Unknown'), 'triangle')
+
+    def test_g_atlas_cyan_maps_to_green(self):
+        self.assertEqual(normalize_filter_name('cyan-ATLAS'), 'g')
+        self.assertEqual(band_display_color('cyan-ATLAS', None), '#008000')
+
+
+class MagnitudeFormatTests(TestCase):
+    def test_two_decimal_places(self):
+        self.assertEqual(format_magnitude(18.3248572), '18.32')
+        self.assertEqual(format_magnitude(None), '-')
+
+    def test_mag_with_error(self):
+        self.assertEqual(format_magnitude_with_error(18.324, 0.0891), '18.32 ± 0.09')
+
+
+class PersonalDashboardPaginationTests(TestCase):
+    def setUp(self):
+        self.user = create_test_user(username='pdash_pagination_user')
+        self.client = Client()
+        self.client.force_login(self.user)
+        self.transient_names = []
+        for i in range(15):
+            t = create_minimal_transient(
+                self.user,
+                name=f'pdash-page-{i:02d}',
+                ra=10.0 + i * 0.01,
+            )
+            self.transient_names.append(t.name)
+
+        names_sql = "', '".join(self.transient_names)
+        sql = (
+            "SELECT name FROM YSE_App_transient "
+            f"WHERE name IN ('{names_sql}') ORDER BY name"
+        )
+        explorer_query = Query.objects.create(
+            title='All transients in YSE PZ',
+            sql=sql,
+            description='Pagination regression test query',
+            snapshot=False,
+            created_by_user=self.user,
+        )
+        self.user_query = UserQuery.objects.create(
+            user=self.user,
+            query=explorer_query,
+            **audit_fields(self.user),
+        )
+        cache.set(
+            f'user_query_{QUERY_CACHE_VERSION}_{self.user_query.id}',
+            self.transient_names,
+            timeout=3600,
+        )
+
+    @mock.patch.dict(os.environ, {'YSE_PERSONAL_DASHBOARD_DEFER': '1'})
+    def test_section_fragment_respects_prefixed_page_param(self):
+        prefix = self.user_query.query.title.replace(' ', '') + '-'
+        page1_url = (
+            f'/personaldashboard/section/{self.user_query.id}/'
+            f'?{prefix}page=1'
+        )
+        page2_url = (
+            f'/personaldashboard/section/{self.user_query.id}/'
+            f'?{prefix}page=2'
+        )
+        page1 = self.client.get(page1_url)
+        page2 = self.client.get(page2_url)
+        self.assertEqual(page1.status_code, 200)
+        self.assertEqual(page2.status_code, 200)
+        body1 = page1.content.decode()
+        body2 = page2.content.decode()
+        self.assertIn(f'{prefix}page=2', body1)
+        self.assertNotEqual(body1, body2)
+        names_on_page1 = [n for n in self.transient_names if n in body1]
+        names_on_page2 = [n for n in self.transient_names if n in body2]
+        self.assertGreater(len(names_on_page1), 0)
+        self.assertGreater(len(names_on_page2), 0)
+        self.assertLessEqual(len(names_on_page1), 10)
+        self.assertLessEqual(len(names_on_page2), 10)
+        self.assertEqual(len(set(names_on_page1) & set(names_on_page2)), 0)
+
+    @mock.patch.dict(os.environ, {'YSE_PERSONAL_DASHBOARD_DEFER': '1'})
+    def test_deferred_shell_passes_query_string_to_section_loader(self):
+        prefix = self.user_query.query.title.replace(' ', '') + '-'
+        response = self.client.get(f'/personaldashboard/?{prefix}page=2')
+        self.assertEqual(response.status_code, 200)
+        body = response.content.decode()
+        self.assertIn('window.location.search', body)
+        self.assertIn('sectionUrl', body)
+
+
+class MagnitudeColumnTests(TestCase):
+    def test_render_formats_to_two_decimals(self):
+        col = MagnitudeColumn()
+        self.assertEqual(col.render(17.4567), '17.46')
+
+    def test_dashboard_annotation_still_numeric(self):
+        user = create_test_user(username='mag_col_user')
+        transient = create_minimal_transient(user, name='mag-col-test')
+        attach_synthetic_photometry(user, transient, n_points=2)
+        row = annotate_dashboard_transient_fields(
+            Transient.objects.filter(pk=transient.pk)
+        ).first()
+        self.assertIsNotNone(row.recent_mag)

--- a/YSE_App/view_utils.py
+++ b/YSE_App/view_utils.py
@@ -24,6 +24,7 @@ from .models import *
 from .data import PhotometryService, SpectraService, ObservingResourceService
 from .serializers import *
 from .common.bandpassdict import bandpassdict
+from .common.filter_display import band_display_color, telescope_display_symbol
 from .common.utilities import date_to_mjd
 
 import copy
@@ -782,11 +783,12 @@ def lightcurveplot_summary(request, transient_id, salt2=False):
 
     for count, band_id in enumerate(unique_bands):
         band_obj = band_lookup[band_id]
-        color = band_obj.disp_color or colorlist[count % len(colorlist)]
-        symbol = band_obj.disp_symbol or "triangle"
-        if band_obj.disp_symbol and band_obj.disp_symbol != 'inverted_triangle':
+        inst_name = band_obj.instrument.name if band_obj.instrument_id else None
+        color = band_display_color(band_obj.name, band_obj.disp_color, fallback_index=count)
+        symbol = telescope_display_symbol(inst_name, band_obj.disp_symbol)
+        if symbol and symbol != 'inverted_triangle':
             try:
-                plotmethod = getattr(ax, band_obj.disp_symbol)
+                plotmethod = getattr(ax, symbol)
             except AttributeError:
                 plotmethod = getattr(ax, 'triangle')  # Default to triangle
         else:
@@ -917,16 +919,15 @@ def lightcurveplot_summary(request, transient_id, salt2=False):
         
         count = 0
         plotmjd = np.arange(result['parameters'][1] - 20, result['parameters'][1] + 50, 0.5)
-        bandunq, idx = np.unique(bandstr, return_index=True)
-        
-        for bs, b, bc in zip(bandunq, band[idx], bandcolor[idx]):
-            color = bc if bc and bc != 'None' else colorlist[count % len(np.unique(colorlist))]
+        for band_id in unique_bands:
+            band_obj = band_lookup[band_id]
+            color = band_display_color(band_obj.name, band_obj.disp_color, fallback_index=count)
             count += 1
-            
-            if bs in bandpassdict.keys() and bandpassdict[bs] in salt2band:
+            bandkey = f'Band: {band_obj.instrument.name} - {band_obj.name}'
+            if bandkey in bandpassdict.keys() and bandpassdict[bandkey] in salt2band:
                 salt2flux = fitted_model.bandflux(
-                    bandpassdict[bs], plotmjd,
-                    zp=27.5, zpsys=zpsys[bandpassdict[bs] == salt2band][0]
+                    bandpassdict[bandkey], plotmjd,
+                    zp=27.5, zpsys=zpsys[bandpassdict[bandkey] == salt2band][0]
                 )
                 ax.line(plotmjd, -2.5 * np.log10(salt2flux) + 27.5, color=color)
         
@@ -1021,16 +1022,13 @@ def lightcurveplot_detail(request, transient_id, salt2=False):
     upperlimmag,upperlimmjd = np.array([]),np.array([])
     for bs,bn,b,bc,bsym,inn in zip(
             bandunq,band_name[idx],band[idx],disp_color[idx],disp_symbol[idx],instrument_name[idx]):
-        if bc != 'None' and bc: color = bc
-        else:
-            coloridx = count % len(np.unique(colorlist))
-            color = colorlist[coloridx]
-            count += 1
-
-        if bsym and bsym != 'inverted_triangle':
+        color = band_display_color(bn, bc, fallback_index=count)
+        count += 1
+        symbol = telescope_display_symbol(inn, bsym)
+        if symbol and symbol != 'inverted_triangle':
             try:
-                plotmethod = getattr(ax, bsym)
-            except:
+                plotmethod = getattr(ax, symbol)
+            except AttributeError:
                 plotmethod = getattr(ax, 'triangle')
         else:
             plotmethod = getattr(ax, 'triangle')
@@ -1198,12 +1196,8 @@ def lightcurveplot_detail(request, transient_id, salt2=False):
                 bandunq,idx = np.unique(band,return_index=True)
                 for bs,bn,b,bc,bsym,inn in zip(
                         bandunq,band_name[idx],band[idx],disp_color[idx],disp_symbol[idx],instrument_name[idx]):
-                    if bc != 'None' and bc:
-                        color = bc
-                    else:
-                        coloridx = count % len(np.unique(colorlist))
-                        color = colorlist[coloridx]
-                        count += 1
+                    color = band_display_color(bn, bc, fallback_index=count)
+                    count += 1
                     bandkey = 'Band: %s - %s'%(inn,bn)
                     if bandkey in bandpassdict.keys() and bandpassdict[bandkey] in salt2band:
                         model_flux = fitted_model.bandflux(
@@ -1300,11 +1294,16 @@ def lightcurveplot_flux(request, transient_id, salt2=False):
             if p.mag_err: magerr = np.append(magerr,p.mag_err)
             else: magerr = np.append(magerr,0)
             bandstr = np.append(bandstr,str(p.band))
-            bandcolor = np.append(bandcolor,str(p.band.disp_color))
-            if p.band.disp_symbol in py2bokeh_symboldict.keys():
-                bandsym = np.append(bandsym,str(py2bokeh_symboldict[p.band.disp_symbol]))
+            inst_name = p.band.instrument.name if p.band.instrument_id else None
+            bandcolor = np.append(
+                bandcolor,
+                band_display_color(p.band.name, p.band.disp_color),
+            )
+            sym = telescope_display_symbol(inst_name, p.band.disp_symbol)
+            if sym in py2bokeh_symboldict.keys():
+                bandsym = np.append(bandsym, str(py2bokeh_symboldict[sym]))
             else:
-                bandsym = np.append(bandsym,str(p.band.disp_symbol))
+                bandsym = np.append(bandsym, str(sym))
             band = np.append(band,p.band)
             if salt2:
                 if str(p.band) in bandpassdict.keys():
@@ -1326,7 +1325,10 @@ def lightcurveplot_flux(request, transient_id, salt2=False):
             upperlimband = np.append(upperlimband,p.band)
             if p.mag_sys is None: upperlimmagsys = np.append(upperlimmagsys,'None')
             else: upperlimmagsys = np.append(upperlimmagsys,p.mag_sys)
-            upperlimbandcolor = np.append(upperlimbandcolor,p.band.disp_color)
+            upperlimbandcolor = np.append(
+                upperlimbandcolor,
+                band_display_color(p.band.name, p.band.disp_color),
+            )
             if salt2:
                 if str(p.band) in bandpassdict.keys():
                     salt2mjd = np.append(salt2mjd,[dbmjd])
@@ -1343,7 +1345,13 @@ def lightcurveplot_flux(request, transient_id, salt2=False):
         upperlimmagsys = np.append(upperlimmagsys,'None')
         upperlimbandstr = np.append(upperlimbandstr,str(transient.non_detect_band))
         upperlimband = np.append(upperlimband,transient.non_detect_band)
-        upperlimbandcolor = np.append(upperlimbandcolor,transient.non_detect_band.disp_color)
+        upperlimbandcolor = np.append(
+            upperlimbandcolor,
+            band_display_color(
+                transient.non_detect_band.name,
+                transient.non_detect_band.disp_color,
+            ),
+        )
         
     colorlist = ['#8dd3c7','#bebada','#fb8072','#80b1d3','#fdb462','#b3de69','#fccde5','#d9d9d9']
     count = 0
@@ -1364,16 +1372,15 @@ def lightcurveplot_flux(request, transient_id, salt2=False):
     
     legend_it = []
     for bs,b,bc,bsym in zip(bandunq,allband[idx],allbandcolor[idx],allbandsym[idx]):
-        if bc != 'None' and bc: color = bc
-        else:
-            coloridx = count % len(np.unique(colorlist))
-            color = colorlist[coloridx]
-            count += 1
-
-        if bsym and bsym != 'inverted_triangle':
+        band_name = b.name if hasattr(b, 'name') else str(bs)
+        color = band_display_color(band_name, bc, fallback_index=count)
+        count += 1
+        inst_name = b.instrument.name if hasattr(b, 'instrument_id') and b.instrument_id else None
+        symbol = telescope_display_symbol(inst_name, bsym if bsym != 'None' else None)
+        if symbol and symbol != 'inverted_triangle':
             try:
-                plotmethod = getattr(ax, bsym)
-            except:
+                plotmethod = getattr(ax, symbol)
+            except AttributeError:
                 plotmethod = getattr(ax, 'triangle')
         else:
             plotmethod = getattr(ax, 'triangle')

--- a/YSE_App/view_utils.py
+++ b/YSE_App/view_utils.py
@@ -24,7 +24,7 @@ from .models import *
 from .data import PhotometryService, SpectraService, ObservingResourceService
 from .serializers import *
 from .common.bandpassdict import bandpassdict
-from .common.filter_display import band_display_color, telescope_display_symbol
+from .common.filter_display import band_display_color, display_filter_label, telescope_display_symbol
 from .common.utilities import date_to_mjd
 
 import copy
@@ -784,6 +784,7 @@ def lightcurveplot_summary(request, transient_id, salt2=False):
     for count, band_id in enumerate(unique_bands):
         band_obj = band_lookup[band_id]
         inst_name = band_obj.instrument.name if band_obj.instrument_id else None
+        short_label = display_filter_label(band_obj.name)
         color = band_display_color(band_obj.name, band_obj.disp_color, fallback_index=count)
         symbol = telescope_display_symbol(inst_name, band_obj.disp_symbol)
         if symbol and symbol != 'inverted_triangle':
@@ -816,7 +817,7 @@ def lightcurveplot_summary(request, transient_id, salt2=False):
                 date=band_obs_date_str.tolist(),
                 data_quality=dq_labels[band_filter].tolist(),
                 magsys=mag_sys[band_filter].tolist(),
-                band=[f"{band_obj.instrument.name} - {band_obj.name}"] * len(band_mjd),
+                band=[short_label] * len(band_mjd),
             )
         )
         plot_func = getattr(ax, symbol, ax.triangle)
@@ -829,7 +830,7 @@ def lightcurveplot_summary(request, transient_id, salt2=False):
         err_ys = [(y - yerr, y + yerr) for y, yerr in zip(band_mag, band_mag_err)]
         ax.multi_line(err_xs, err_ys, color=color, muted_alpha=0.2)
 
-        legend_items.append((f"{band_obj.instrument.name} - {band_obj.name}", [plot]))
+        legend_items.append((short_label, [plot]))
 
         # SALT2 processing
         if salt2 and str(band_obj.name) in bandpassdict.keys():
@@ -957,7 +958,7 @@ def lightcurveplot_detail(request, transient_id, salt2=False):
 
     cache_key = None
     if not salt2 and _plot_html_cache_enabled():
-        cache_key = f'lc_detail_v1_{transient_id}_{_transient_phot_cache_token(transient_id)}'
+        cache_key = f'lc_detail_v2_{transient_id}_{_transient_phot_cache_token(transient_id)}'
         cached_html = cache.get(cache_key)
         if cached_html is not None:
             return django.http.HttpResponse(cached_html)
@@ -1022,6 +1023,7 @@ def lightcurveplot_detail(request, transient_id, salt2=False):
     upperlimmag,upperlimmjd = np.array([]),np.array([])
     for bs,bn,b,bc,bsym,inn in zip(
             bandunq,band_name[idx],band[idx],disp_color[idx],disp_symbol[idx],instrument_name[idx]):
+        short_label = display_filter_label(bn)
         color = band_display_color(bn, bc, fallback_index=count)
         count += 1
         symbol = telescope_display_symbol(inn, bsym)
@@ -1065,7 +1067,7 @@ def lightcurveplot_detail(request, transient_id, salt2=False):
                                             date=obs_dates_str[iPlot].tolist(),
                                             data_quality=data_quality[iPlot].tolist(),
                                             magsys=mag_sys[iPlot].tolist(),
-                                            band=['%s - %s'%(inn,bn)]*len(mjds[iPlot].tolist())))
+                                            band=[short_label]*len(mjds[iPlot].tolist())))
             
         p_det = plotmethod('x','y',source=source,
                    color=color,size=size, muted_alpha=0.2)
@@ -1081,7 +1083,7 @@ def lightcurveplot_detail(request, transient_id, salt2=False):
                                                 date=obs_dates_str[iPlotUlimFlux][iPlotUlimFlux2][iPlotUlimFlux3].tolist(),
                                                 data_quality=data_quality[iPlotUlimFlux][iPlotUlimFlux2][iPlotUlimFlux3].tolist(),
                                                 magsys=mag_sys[iPlotUlimFlux][iPlotUlimFlux2][iPlotUlimFlux3].tolist(),
-                                                band=['%s - %s'%(inn,bn)]*len(ulim_x)))
+                                                band=[short_label]*len(ulim_x)))
 
             p_ulim = ax.inverted_triangle('x','y',source=source,
                                      color=color,size=5,muted_alpha=0.2)
@@ -1094,7 +1096,7 @@ def lightcurveplot_detail(request, transient_id, salt2=False):
             err_ys.append((y - yerr, y + yerr))
         ax.multi_line(err_xs, err_ys, color=color, muted_alpha=0.2)#, legend='%s - %s'%(
 
-        legend_it.append(('%s - %s'%(inn,bn), [p_det]))
+        legend_it.append((short_label, [p_det]))
 
     today = Time(datetime.datetime.today()).mjd
     p_today = ax.line(today,20,line_width=3,line_color='black')
@@ -1372,8 +1374,9 @@ def lightcurveplot_flux(request, transient_id, salt2=False):
     
     legend_it = []
     for bs,b,bc,bsym in zip(bandunq,allband[idx],allbandcolor[idx],allbandsym[idx]):
-        band_name = b.name if hasattr(b, 'name') else str(bs)
-        color = band_display_color(band_name, bc, fallback_index=count)
+        raw_band_name = b.name if hasattr(b, 'name') else str(bs)
+        short_label = display_filter_label(raw_band_name)
+        color = band_display_color(raw_band_name, bc, fallback_index=count)
         count += 1
         inst_name = b.instrument.name if hasattr(b, 'instrument_id') and b.instrument_id else None
         symbol = telescope_display_symbol(inst_name, bsym if bsym != 'None' else None)
@@ -1392,7 +1395,7 @@ def lightcurveplot_flux(request, transient_id, salt2=False):
                                             date=date[bandstr == bs].tolist(),
                                             data_quality=data_quality[bandstr == bs].tolist(),
                                             magsys=magsys[bandstr == bs].tolist(),
-                                            band=[bs.replace('Band: ','')]*len(mjd[bandstr == bs].tolist())))
+                                            band=[short_label]*len(mjd[bandstr == bs].tolist())))
 
         p = plotmethod('x','y',source=source,
                    color=color,size=size, muted_alpha=0.2)#,legend='%s - %s'%(
@@ -1408,7 +1411,7 @@ def lightcurveplot_flux(request, transient_id, salt2=False):
             err_ys.append((y - yerr, y + yerr))
         ax.multi_line(err_xs, err_ys, color=color, muted_alpha=0.2)
 
-        legend_it.append(('%s - %s'%(b.instrument.telescope.name,b.name), [p]))
+        legend_it.append((short_label, [p]))
         
     today = Time(datetime.datetime.today()).mjd
     p = ax.line(today,20,line_width=3,line_color='black')
@@ -1965,9 +1968,21 @@ def get_ps1_image(request,transient_id):
     jpegurldict = {"jpegurl":jpegurl,"msg":"success"}
     return(JsonResponse(jpegurldict))
 
+def _archive_status_with_timeout(work, *, timeout_seconds=8):
+    """Run a blocking archive lookup with a wall-clock timeout."""
+    from concurrent.futures import ThreadPoolExecutor, TimeoutError as FuturesTimeout
+
+    with ThreadPoolExecutor(max_workers=1) as pool:
+        future = pool.submit(work)
+        try:
+            return future.result(timeout=timeout_seconds)
+        except FuturesTimeout:
+            return None
+
+
 def get_hst_status(request, transient_id):
     """Lightweight HST availability for tab label (no JPG fetch)."""
-    cache_key = f'hst_status_v1_{transient_id}'
+    cache_key = f'hst_status_v2_{transient_id}'
     cached = cache.get(cache_key)
     if cached is not None:
         return JsonResponse(cached)
@@ -1975,14 +1990,22 @@ def get_hst_status(request, transient_id):
         t = Transient.objects.get(pk=transient_id)
     except Transient.DoesNotExist:
         raise Http404("Transient id does not exist")
-    try:
+
+    def _lookup():
         from . import common
         hst = common.mast_query.hstImages(t.ra, t.dec, 'Object')
         hst.getObstable()
         count = int(getattr(hst, 'Nimages', 0) or 0)
         if not count and getattr(hst, 'obstable', None) is not None:
             count = len(hst.obstable)
-        payload = {'has_data': count > 0, 'count': count}
+        return count
+
+    try:
+        count = _archive_status_with_timeout(_lookup)
+        if count is None:
+            payload = {'has_data': False, 'count': 0, 'timed_out': True}
+        else:
+            payload = {'has_data': count > 0, 'count': count}
     except Exception:
         payload = {'has_data': False, 'count': 0}
     cache.set(cache_key, payload, timeout=3600)
@@ -1991,7 +2014,7 @@ def get_hst_status(request, transient_id):
 
 def get_chandra_status(request, transient_id):
     """Lightweight Chandra availability for tab label (no image fetch)."""
-    cache_key = f'chandra_status_v1_{transient_id}'
+    cache_key = f'chandra_status_v2_{transient_id}'
     cached = cache.get(cache_key)
     if cached is not None:
         return JsonResponse(cached)
@@ -1999,12 +2022,19 @@ def get_chandra_status(request, transient_id):
         t = Transient.objects.get(pk=transient_id)
     except Transient.DoesNotExist:
         raise Http404("Transient id does not exist")
-    try:
+
+    def _lookup():
         from . import common
         chr = common.chandra_query.chandraImages(t.ra, t.dec, 'Object')
         chr.search_chandra_database()
-        count = int(getattr(chr, 'n_obsid', 0) or 0)
-        payload = {'has_data': count > 0, 'count': count}
+        return int(getattr(chr, 'n_obsid', 0) or 0)
+
+    try:
+        count = _archive_status_with_timeout(_lookup)
+        if count is None:
+            payload = {'has_data': False, 'count': 0, 'timed_out': True}
+        else:
+            payload = {'has_data': count > 0, 'count': count}
     except Exception:
         payload = {'has_data': False, 'count': 0}
     cache.set(cache_key, payload, timeout=3600)

--- a/YSE_App/view_utils.py
+++ b/YSE_App/view_utils.py
@@ -24,7 +24,13 @@ from .models import *
 from .data import PhotometryService, SpectraService, ObservingResourceService
 from .serializers import *
 from .common.bandpassdict import bandpassdict
-from .common.filter_display import band_display_color, display_filter_label, telescope_display_symbol
+from .common.filter_display import (
+    band_display_color,
+    display_filter_label,
+    plot_legend_label,
+    telescope_display_name,
+    telescope_display_symbol,
+)
 from .common.utilities import date_to_mjd
 
 import copy
@@ -725,7 +731,9 @@ def lightcurveplot_summary(request, transient_id, salt2=False):
 
     # Pre-fetch related band data to avoid repeated lookups
     band_ids = photdata.values_list("band", flat=True).distinct()
-    band_data = PhotometricBand.objects.filter(pk__in=band_ids).select_related("instrument")
+    band_data = PhotometricBand.objects.filter(pk__in=band_ids).select_related(
+        "instrument", "instrument__telescope"
+    )
     band_lookup = {b.pk: b for b in band_data}
 
     phot_rows = list(photdata)
@@ -766,7 +774,8 @@ def lightcurveplot_summary(request, transient_id, salt2=False):
     colorlist = ['#8dd3c7', '#bebada', '#fb8072', '#80b1d3', '#fdb462', '#b3de69', '#fccde5', '#d9d9d9']
     TOOLTIPS = [
         ("mag", "$y"),
-        ("band", "@band"),
+        ("telescope", "@telescope"),
+        ("filter", "@filter"),
         ("date", "@date"),
         ("dq", "@data_quality"),
         ("magsys", "@magsys"),
@@ -784,7 +793,18 @@ def lightcurveplot_summary(request, transient_id, salt2=False):
     for count, band_id in enumerate(unique_bands):
         band_obj = band_lookup[band_id]
         inst_name = band_obj.instrument.name if band_obj.instrument_id else None
-        short_label = display_filter_label(band_obj.name)
+        tel_name = (
+            band_obj.instrument.telescope.name
+            if band_obj.instrument_id and band_obj.instrument.telescope_id
+            else None
+        )
+        legend_label = plot_legend_label(
+            band_obj.name,
+            instrument_name=inst_name,
+            telescope_name=tel_name,
+        )
+        short_filter = display_filter_label(band_obj.name)
+        tel_label = telescope_display_name(inst_name, tel_name)
         color = band_display_color(band_obj.name, band_obj.disp_color, fallback_index=count)
         symbol = telescope_display_symbol(inst_name, band_obj.disp_symbol)
         if symbol and symbol != 'inverted_triangle':
@@ -817,7 +837,8 @@ def lightcurveplot_summary(request, transient_id, salt2=False):
                 date=band_obs_date_str.tolist(),
                 data_quality=dq_labels[band_filter].tolist(),
                 magsys=mag_sys[band_filter].tolist(),
-                band=[short_label] * len(band_mjd),
+                telescope=[tel_label] * len(band_mjd),
+                filter=[short_filter] * len(band_mjd),
             )
         )
         plot_func = getattr(ax, symbol, ax.triangle)
@@ -830,7 +851,7 @@ def lightcurveplot_summary(request, transient_id, salt2=False):
         err_ys = [(y - yerr, y + yerr) for y, yerr in zip(band_mag, band_mag_err)]
         ax.multi_line(err_xs, err_ys, color=color, muted_alpha=0.2)
 
-        legend_items.append((short_label, [plot]))
+        legend_items.append((legend_label, [plot]))
 
         # SALT2 processing
         if salt2 and str(band_obj.name) in bandpassdict.keys():
@@ -958,7 +979,7 @@ def lightcurveplot_detail(request, transient_id, salt2=False):
 
     cache_key = None
     if not salt2 and _plot_html_cache_enabled():
-        cache_key = f'lc_detail_v2_{transient_id}_{_transient_phot_cache_token(transient_id)}'
+        cache_key = f'lc_detail_v4_{transient_id}_{_transient_phot_cache_token(transient_id)}'
         cached_html = cache.get(cache_key)
         if cached_html is not None:
             return django.http.HttpResponse(cached_html)
@@ -985,7 +1006,7 @@ def lightcurveplot_detail(request, transient_id, salt2=False):
         b.pk: b
         for b in PhotometricBand.objects.filter(
             pk__in={p.band_id for p in phot_rows}
-        ).select_related('instrument')
+        ).select_related('instrument', 'instrument__telescope')
     }
 
     fluxes = np.array([p.flux for p in phot_rows], dtype=object)
@@ -1012,7 +1033,8 @@ def lightcurveplot_detail(request, transient_id, salt2=False):
     colorlist = ['#8dd3c7','#bebada','#fb8072','#80b1d3','#fdb462','#b3de69','#fccde5','#d9d9d9']
     TOOLTIPS = [
         ('mag','$y'),
-        ('band','@band'),
+        ('telescope','@telescope'),
+        ('filter','@filter'),
         ('date','@date'),
         ('dq','@data_quality'),
         ('magsys','@magsys')]
@@ -1023,7 +1045,15 @@ def lightcurveplot_detail(request, transient_id, salt2=False):
     upperlimmag,upperlimmjd = np.array([]),np.array([])
     for bs,bn,b,bc,bsym,inn in zip(
             bandunq,band_name[idx],band[idx],disp_color[idx],disp_symbol[idx],instrument_name[idx]):
-        short_label = display_filter_label(bn)
+        band_obj = band_lookup[b]
+        tel_name = (
+            band_obj.instrument.telescope.name
+            if band_obj.instrument.telescope_id
+            else None
+        )
+        legend_label = plot_legend_label(bn, instrument_name=inn, telescope_name=tel_name)
+        short_filter = display_filter_label(bn)
+        tel_label = telescope_display_name(inn, tel_name)
         color = band_display_color(bn, bc, fallback_index=count)
         count += 1
         symbol = telescope_display_symbol(inn, bsym)
@@ -1067,7 +1097,8 @@ def lightcurveplot_detail(request, transient_id, salt2=False):
                                             date=obs_dates_str[iPlot].tolist(),
                                             data_quality=data_quality[iPlot].tolist(),
                                             magsys=mag_sys[iPlot].tolist(),
-                                            band=[short_label]*len(mjds[iPlot].tolist())))
+                                            telescope=[tel_label]*len(mjds[iPlot].tolist()),
+                                            filter=[short_filter]*len(mjds[iPlot].tolist())))
             
         p_det = plotmethod('x','y',source=source,
                    color=color,size=size, muted_alpha=0.2)
@@ -1083,7 +1114,8 @@ def lightcurveplot_detail(request, transient_id, salt2=False):
                                                 date=obs_dates_str[iPlotUlimFlux][iPlotUlimFlux2][iPlotUlimFlux3].tolist(),
                                                 data_quality=data_quality[iPlotUlimFlux][iPlotUlimFlux2][iPlotUlimFlux3].tolist(),
                                                 magsys=mag_sys[iPlotUlimFlux][iPlotUlimFlux2][iPlotUlimFlux3].tolist(),
-                                                band=[short_label]*len(ulim_x)))
+                                                telescope=[tel_label]*len(ulim_x),
+                                                filter=[short_filter]*len(ulim_x)))
 
             p_ulim = ax.inverted_triangle('x','y',source=source,
                                      color=color,size=5,muted_alpha=0.2)
@@ -1096,7 +1128,7 @@ def lightcurveplot_detail(request, transient_id, salt2=False):
             err_ys.append((y - yerr, y + yerr))
         ax.multi_line(err_xs, err_ys, color=color, muted_alpha=0.2)#, legend='%s - %s'%(
 
-        legend_it.append((short_label, [p_det]))
+        legend_it.append((legend_label, [p_det]))
 
     today = Time(datetime.datetime.today()).mjd
     p_today = ax.line(today,20,line_width=3,line_color='black')
@@ -1365,7 +1397,8 @@ def lightcurveplot_flux(request, transient_id, salt2=False):
 
     TOOLTIPS = [
         ('mag','$y'),
-        ('band','@band'),
+        ('telescope','@telescope'),
+        ('filter','@filter'),
         ('date','@date'),
         ('dq','@data_quality'),
         ('magsys','@magsys')]
@@ -1375,7 +1408,14 @@ def lightcurveplot_flux(request, transient_id, salt2=False):
     legend_it = []
     for bs,b,bc,bsym in zip(bandunq,allband[idx],allbandcolor[idx],allbandsym[idx]):
         raw_band_name = b.name if hasattr(b, 'name') else str(bs)
-        short_label = display_filter_label(raw_band_name)
+        short_filter = display_filter_label(raw_band_name)
+        tel_label = telescope_display_name(
+            b.instrument.name if hasattr(b, 'instrument_id') and b.instrument_id else None,
+            b.instrument.telescope.name
+            if hasattr(b, 'instrument') and getattr(b.instrument, 'telescope_id', None)
+            else None,
+        )
+        legend_label = f'{tel_label} {short_filter}'
         color = band_display_color(raw_band_name, bc, fallback_index=count)
         count += 1
         inst_name = b.instrument.name if hasattr(b, 'instrument_id') and b.instrument_id else None
@@ -1395,7 +1435,8 @@ def lightcurveplot_flux(request, transient_id, salt2=False):
                                             date=date[bandstr == bs].tolist(),
                                             data_quality=data_quality[bandstr == bs].tolist(),
                                             magsys=magsys[bandstr == bs].tolist(),
-                                            band=[short_label]*len(mjd[bandstr == bs].tolist())))
+                                            telescope=[tel_label]*len(mjd[bandstr == bs].tolist()),
+                                            filter=[short_filter]*len(mjd[bandstr == bs].tolist())))
 
         p = plotmethod('x','y',source=source,
                    color=color,size=size, muted_alpha=0.2)#,legend='%s - %s'%(
@@ -1411,7 +1452,7 @@ def lightcurveplot_flux(request, transient_id, salt2=False):
             err_ys.append((y - yerr, y + yerr))
         ax.multi_line(err_xs, err_ys, color=color, muted_alpha=0.2)
 
-        legend_it.append((short_label, [p]))
+        legend_it.append((legend_label, [p]))
         
     today = Time(datetime.datetime.today()).mjd
     p = ax.line(today,20,line_width=3,line_color='black')

--- a/YSE_App/views.py
+++ b/YSE_App/views.py
@@ -50,6 +50,7 @@ import dateutil.parser
 from astroplan import moon_illumination
 from astropy.time import Time
 from .common.utilities import getRADecBox
+from YSE_App.common.magnitude_format import format_magnitude_with_error
 
 from .table_utils import (
     TransientTable,
@@ -214,6 +215,36 @@ def _personaldashboard_failed_row(q, title):
     return (Transient.objects.none(), title, '', None, q.id, 0)
 
 
+def _personaldashboard_sql_query_prefix(query_title):
+    """django-tables2 uses prefix + page_field; trailing '-' yields {title}-page params."""
+    return query_title.replace(' ', '') + '-'
+
+
+def _personaldashboard_request_get(request, prefix):
+    """Normalize legacy {Title}page=N query params to {Title}-page=N."""
+    qd = request.GET.copy()
+    bare_prefix = prefix.rstrip('-')
+    for suffix in ('page', 'sort', 'per_page'):
+        legacy_key = f'{bare_prefix}{suffix}'
+        modern_key = f'{prefix}{suffix}'
+        if legacy_key in qd and modern_key not in qd:
+            qd[modern_key] = qd[legacy_key]
+    return qd
+
+
+def _personaldashboard_configure_table(request, prefix, queryset):
+    """Build filter + paginated table for one personal-dashboard SQL section."""
+    saved_get = request.GET
+    request.GET = _personaldashboard_request_get(request, prefix)
+    try:
+        transient_filter = TransientFilter(request.GET, queryset=queryset, prefix=prefix)
+        table = TransientTable(transient_filter.qs, prefix=prefix)
+        RequestConfig(request, paginate={'per_page': 10}).configure(table)
+        return table, transient_filter
+    finally:
+        request.GET = saved_get
+
+
 def _personaldashboard_table_for_user_query(request, q):
     """Build one dashboard section tuple for a single UserQuery."""
     if q.query:
@@ -230,20 +261,20 @@ def _personaldashboard_table_for_user_query(request, q):
                 cache.set(cache_key, cached_result, timeout=3600)
                 cursor.close()
             if not cached_result:
-                prefix = q.query.title.replace(' ', '')
+                prefix = _personaldashboard_sql_query_prefix(q.query.title)
                 empty_qs = annotate_dashboard_transient_fields(Transient.objects.none())
-                transient_filter = TransientFilter(request.GET, queryset=empty_qs, prefix=prefix)
-                table = TransientTable(transient_filter.qs, prefix=prefix)
-                RequestConfig(request, paginate={'per_page': 10}).configure(table)
+                table, transient_filter = _personaldashboard_configure_table(
+                    request, prefix, empty_qs
+                )
                 return (table, q.query.title, prefix, transient_filter, q.id, 0)
             base_transients = annotate_dashboard_transient_fields(
                 Transient.objects.filter(name__in=cached_result).order_by('-disc_date')
             )
-            prefix = q.query.title.replace(' ', '')
+            prefix = _personaldashboard_sql_query_prefix(q.query.title)
             section_qs = base_transients.filter(name__in=cached_result)
-            transient_filter = TransientFilter(request.GET, queryset=section_qs, prefix=prefix)
-            table = TransientTable(transient_filter.qs, prefix=prefix)
-            RequestConfig(request, paginate={'per_page': 10}).configure(table)
+            table, transient_filter = _personaldashboard_configure_table(
+                request, prefix, section_qs
+            )
             return (table, q.query.title, prefix, transient_filter, q.id, len(cached_result))
         except Exception as e:
             cache.delete(f'user_query_{QUERY_CACHE_VERSION}_{q.id}')
@@ -317,11 +348,11 @@ def _personaldashboard_build_all_tables(request, queries):
         base_transients = Transient.objects.none()
 
     for q, transient_names in sql_dashboard_sections:
-        prefix = q.query.title.replace(' ', '')
+        prefix = _personaldashboard_sql_query_prefix(q.query.title)
         section_qs = base_transients.filter(name__in=transient_names)
-        transient_filter = TransientFilter(request.GET, queryset=section_qs, prefix=prefix)
-        table = TransientTable(transient_filter.qs, prefix=prefix)
-        RequestConfig(request, paginate={'per_page': 10}).configure(table)
+        table, transient_filter = _personaldashboard_configure_table(
+            request, prefix, section_qs
+        )
         tables.append(
             (table, q.query.title, prefix, transient_filter, q.id, len(transient_names))
         )
@@ -1577,10 +1608,14 @@ def transient_detail(request, slug):
                  transient_followup_form.fields["valid_stop"].initial.strftime('%m/%d/%Y HH:MM'))           
         
         if lastphotdata and firstphotdata:
-            context['recent_mag'] = lastphotdata.mag
+            context['recent_mag'] = format_magnitude_with_error(
+                lastphotdata.mag, lastphotdata.mag_err
+            )
             context['recent_filter'] = lastphotdata.band
             context['recent_magdate'] = lastphotdata.obs_date
-            context['first_mag'] = firstphotdata.mag
+            context['first_mag'] = format_magnitude_with_error(
+                firstphotdata.mag, firstphotdata.mag_err
+            )
             context['first_filter'] = firstphotdata.band
             context['first_magdate'] = firstphotdata.obs_date
             if allphotdata is not None:


### PR DESCRIPTION
## Summary
- Add canonical Swope/PS1 uBVgrizy filter colors and telescope symbol shapes for light-curve plots (#108).
- Show light-curve legends as **telescope + short filter** (e.g. `ZTF r`, `PS1 g`) with separate tooltip fields; DB band names unchanged.
- Show **No HST** / **No Chandra** tab labels when archives are empty; preload deferred transient-detail tab fragments in the background (#109, #110).
- Fix deferred tab loading: move fragment loader into early page script so follow-up datepicker init no longer blocks tab AJAX (#110).
- Fix personal-dashboard pagination for deferred query sections: pass URL query params to section AJAX loads, use django-tables2-compatible `{title}-page` prefixes, and accept legacy `{title}page` params (#111).
- Format discovery/last magnitudes (and errors on transient detail) to two decimal places across dashboard tables and summary context (#112).

## Filter color groups (review / adjust as needed)

| Filter family | Color | Example band names |
|---|---|---|
| u | `#ff7f0e` | u, u-PS1, up |
| B | `#1f77b4` | B, B-Johnson |
| V | `#8FBC8F` | V, V-Johnson, V-crts |
| g | `#008000` | g, g-ZTF, g-WFT, g-Sloan, g-PTF, cyan-ATLAS |
| r | `#DC143C` | r, r-ZTF, r-WFT, r-Sloan, R-Cousins, orange-ATLAS |
| i | `#8c465b` | i, i-ZTF, i-Sloan, I-Cousins, ip |
| z | `#800080` | z, z-Sloan, zp |
| y | `#C9A227` | y, y-PS1 |
| w | `#EBBE0C` | w, w-PS1 |

## Telescope symbol groups

| Shape | Telescopes |
|---|---|
| diamond | ZTF, Swift/UVOT |
| square | PS1 (GPC1), HST |
| circle | Swope |
| asterisk | ATLAS (ACAM) |
| hex | P200 Direct |
| dash | LCO Sinistro / PIXIS |
| star | DECam (ACP) |
| triangle | SOAR / STA1600 (default fallback) |
| cross | PTF |

## Test plan
- [x] `python3 manage.py test YSE_App.tests.test_ui_regressions --keepdb` (13 tests, Docker web container)
- [x] Spot-check transient detail (2026fbf, 2026fbn): deferred tabs load; LC legends show telescope + short filter
- [ ] Personal dashboard: load multi-page saved query, click page 2+, verify different rows
- [x] Light curve: confirm r-ZTF / r-WFT / Swope r share color; ZTF vs Swope use different symbols

Closes #108, #109, #110, #111, #112.