### PR TITLE
Group-based plot cache hardening and security regression coverage

### DIFF
--- a/YSE_App/apps.py
+++ b/YSE_App/apps.py
@@ -3,3 +3,7 @@ from django.apps import AppConfig
 
 class YseAppConfig(AppConfig):
     name = 'YSE_App'
+
+    def ready(self):
+        import YSE_App.signals  # noqa: F401
+

--- a/YSE_App/common/collaboration_groups.py
+++ b/YSE_App/common/collaboration_groups.py
@@ -1,0 +1,73 @@
+"""
+Collaboration group names and helpers for ingest / visibility.
+
+``Public`` is the scrub-script collaboration group for world-readable TNS data.
+"""
+
+from __future__ import annotations
+
+from typing import Iterable, List, Sequence, Union
+
+PUBLIC_COLLABORATION_GROUP_NAME = "Public"
+
+# Collaboration groups applied to photometry/spectra ingested from TNS.
+TNS_IMPORT_COLLABORATION_GROUPS: Sequence[str] = (PUBLIC_COLLABORATION_GROUP_NAME,)
+
+GroupNamesInput = Union[str, Sequence[str], None]
+
+
+def normalize_collaboration_group_names(value: GroupNamesInput) -> List[str]:
+    """Accept comma-separated strings or sequences of group names."""
+    if not value:
+        return []
+    if isinstance(value, str):
+        return [part.strip() for part in value.split(",") if part.strip()]
+    return [str(part).strip() for part in value if str(part).strip()]
+
+
+def collaboration_groups_from_photometry_upload(photometry: dict) -> List[str]:
+    """Read group names from a photometry upload block (header or photdata rows)."""
+    header_groups = normalize_collaboration_group_names(photometry.get("groups"))
+    if header_groups:
+        return header_groups
+    names: set[str] = set()
+    for point in photometry.get("photdata", {}).values():
+        names.update(normalize_collaboration_group_names(point.get("groups")))
+    return sorted(names)
+
+
+def apply_collaboration_groups_to_photometry(transientphot, group_names: Iterable[str]) -> None:
+    """Attach collaboration groups to a saved ``TransientPhotometry`` row."""
+    from django.contrib.auth.models import Group
+
+    if not transientphot.pk or not group_names:
+        return
+    for name in group_names:
+        group = Group.objects.filter(name=name).first()
+        if group is None:
+            continue
+        if not transientphot.groups.filter(pk=group.pk).exists():
+            transientphot.groups.add(group)
+
+
+def get_or_create_public_group():
+    """Return the ``Public`` collaboration group, creating it if needed."""
+    from django.contrib.auth.models import Group
+
+    group, _ = Group.objects.get_or_create(name=PUBLIC_COLLABORATION_GROUP_NAME)
+    return group
+
+
+def ensure_user_has_public_group(user) -> bool:
+    """
+    Add ``Public`` to the user's collaboration groups if missing.
+
+    Returns True when membership was added, False if already present.
+    """
+    if user is None or not getattr(user, "pk", None):
+        return False
+    public_group = get_or_create_public_group()
+    if user.groups.filter(pk=public_group.pk).exists():
+        return False
+    user.groups.add(public_group)
+    return True

--- a/YSE_App/data_ingest/TNS_uploads.py
+++ b/YSE_App/data_ingest/TNS_uploads.py
@@ -40,6 +40,10 @@ from itertools import islice
 from astropy.cosmology import FlatLambdaCDM
 import sys
 from YSE_App.common import mast_query,chandra_query,spitzer_query
+from YSE_App.common.collaboration_groups import (
+    PUBLIC_COLLABORATION_GROUP_NAME,
+    TNS_IMPORT_COLLABORATION_GROUPS,
+)
 from YSE_App.data_ingest.tns_api_client import tns_marker_user_agent
 from django_cron import CronJobBase, Schedule
 from django.conf import settings as djangoSettings
@@ -439,6 +443,7 @@ class processTNS:
             
             photometrydict = {'instrument':ins,
                               'obs_group':obsgroup,
+                              'groups': list(TNS_IMPORT_COLLABORATION_GROUPS),
                               'photdata':{}}
 
             for f,k in zip(np.unique(tfilt),range(len(np.unique(tfilt)))):
@@ -450,7 +455,7 @@ class processTNS:
                     if not m and not me: continue #and not flx and not fe: continue
                     PhotUploadDict = {'obs_date':od.replace(' ','T'),
                                       'band':f,
-                                      'groups':[]}
+                                      'groups': list(TNS_IMPORT_COLLABORATION_GROUPS)}
                     if m: PhotUploadDict['mag'] = m
                     else: PhotUploadDict['mag'] = None
                     if me: PhotUploadDict['mag_err'] = me
@@ -571,6 +576,7 @@ class processTNS:
             Spectrum['instrument'] = si
             Spectrum['obs_date'] = so
             Spectrum['obs_group'] = re.sub(r'[^\x00-\x7f]',r'',sog)
+            Spectrum['groups'] = PUBLIC_COLLABORATION_GROUP_NAME
             SpecDictAll[s] = Spectrum
 
         return SpecDictAll

--- a/YSE_App/data_utils.py
+++ b/YSE_App/data_utils.py
@@ -40,6 +40,11 @@ def _safe_sendemail(*args, **kwargs):
         sendemail(*args, **kwargs)
     except Exception as exc:
         print(f'Email notification failed: {exc}')
+from .common.collaboration_groups import (
+    apply_collaboration_groups_to_photometry,
+    collaboration_groups_from_photometry_upload,
+    normalize_collaboration_group_names,
+)
 from .common.utilities import getRADecBox
 from django.db.models import Q
 from .queries.yse_python_queries import *
@@ -869,6 +874,10 @@ def add_transient_phot_util(photdict,transient,user,do_photdata=True):
                         p['diffimg']['phot_data_id'] = e.id
                         TransientDiffImage.objects.create(**p['diffimg'])
 
+        group_names = collaboration_groups_from_photometry_upload(photometry)
+        if transientphot.pk:
+            apply_collaboration_groups_to_photometry(transientphot, group_names)
+
     return_dict = {"message":"successfully added phot data"}
     return JsonResponse(return_dict),transientphot_entries
 
@@ -890,7 +899,7 @@ def add_transient_spec_util(specdict,transient,user):
 
         allgroups = []
         if 'groups' in spectrum.keys() and spectrum['groups']:
-            for specgroup in spectrum['groups'].split(','):
+            for specgroup in normalize_collaboration_group_names(spectrum['groups']):
                 group = Group.objects.filter(name=specgroup)
                 if not len(group):
                     return_dict = {"message":"group %s is not in DB"%hd['groups']}
@@ -917,6 +926,7 @@ def add_transient_spec_util(specdict,transient,user):
         spectrum['transient'] = transient
         spectrum_copy = spectrum.copy()
         del spectrum_copy['specdata']
+        spectrum_copy.pop('groups', None)
 
         if not len(transientspec):
             transientspec = TransientSpectrum.objects.create(**spectrum_copy)

--- a/YSE_App/management/commands/ensure_users_in_public_group.py
+++ b/YSE_App/management/commands/ensure_users_in_public_group.py
@@ -1,0 +1,58 @@
+"""
+Ensure every user belongs to the Public collaboration group.
+
+Run after importing a server snapshot::
+
+  docker exec ysepz_web_container python3 manage.py ensure_users_in_public_group
+  docker exec ysepz_web_container python3 manage.py ensure_users_in_public_group --dry-run
+"""
+
+from __future__ import annotations
+
+from django.contrib.auth import get_user_model
+from django.core.management.base import BaseCommand
+
+from YSE_App.common.collaboration_groups import (
+    PUBLIC_COLLABORATION_GROUP_NAME,
+    ensure_user_has_public_group,
+    get_or_create_public_group,
+)
+
+User = get_user_model()
+
+
+class Command(BaseCommand):
+    help = "Add the Public collaboration group to every user who lacks it."
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--dry-run",
+            action="store_true",
+            help="Report counts only; do not update the database.",
+        )
+
+    def handle(self, *args, **options):
+        dry_run = options["dry_run"]
+        public_group = get_or_create_public_group()
+        missing = User.objects.exclude(groups=public_group)
+        count = missing.count()
+        total = User.objects.count()
+
+        self.stdout.write(
+            f"Users missing {PUBLIC_COLLABORATION_GROUP_NAME!r}: {count} of {total}"
+        )
+
+        if dry_run:
+            self.stdout.write(self.style.WARNING("Dry run — no changes made."))
+            return
+
+        added = 0
+        for user in missing.iterator():
+            if ensure_user_has_public_group(user):
+                added += 1
+
+        self.stdout.write(
+            self.style.SUCCESS(
+                f"Added {PUBLIC_COLLABORATION_GROUP_NAME!r} to {added} user(s)."
+            )
+        )

--- a/YSE_App/management/commands/mark_tns_imports_public.py
+++ b/YSE_App/management/commands/mark_tns_imports_public.py
@@ -1,0 +1,88 @@
+"""
+Tag existing TNS-import photometry and spectra with the Public collaboration group.
+
+Run against the default database after importing a server snapshot::
+
+  docker exec ysepz_web_container python3 manage.py mark_tns_imports_public
+  docker exec ysepz_web_container python3 manage.py mark_tns_imports_public --dry-run
+"""
+
+from __future__ import annotations
+
+import re
+
+from django.contrib.auth.models import Group
+from django.core.management.base import BaseCommand
+from django.db.models import Q
+
+from YSE_App.common.collaboration_groups import PUBLIC_COLLABORATION_GROUP_NAME
+from YSE_App.models import TransientPhotometry, TransientSpectrum
+
+# Standard TNS IAU names (e.g. 2026fba) — same filter used in TNS_uploads ingest.
+TNS_TRANSIENT_NAME_RE = re.compile(r"^20[0-9]{2}[a-zA-Z][a-zA-Z0-9]*$")
+
+
+def tns_transient_name_q() -> Q:
+    return Q(transient__name__regex=TNS_TRANSIENT_NAME_RE.pattern)
+
+
+class Command(BaseCommand):
+    help = (
+        "Add the Public collaboration group to TNS transient photometry and spectra "
+        "that have no groups M2M rows yet."
+    )
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--dry-run",
+            action="store_true",
+            help="Report counts only; do not update the database.",
+        )
+
+    def handle(self, *args, **options):
+        dry_run = options["dry_run"]
+        public_group, created = Group.objects.get_or_create(
+            name=PUBLIC_COLLABORATION_GROUP_NAME,
+        )
+        if created:
+            self.stdout.write(f"Created collaboration group {PUBLIC_COLLABORATION_GROUP_NAME!r}")
+
+        phot_qs = (
+            TransientPhotometry.objects.filter(tns_transient_name_q())
+            .filter(groups__isnull=True)
+            .distinct()
+        )
+        spec_qs = (
+            TransientSpectrum.objects.filter(tns_transient_name_q())
+            .filter(groups__isnull=True)
+            .distinct()
+        )
+
+        phot_count = phot_qs.count()
+        spec_count = spec_qs.count()
+        self.stdout.write(
+            f"TNS photometry headers to tag: {phot_count}; spectra: {spec_count}"
+        )
+
+        if dry_run:
+            self.stdout.write(self.style.WARNING("Dry run — no changes made."))
+            return
+
+        tagged_phot = 0
+        for phot in phot_qs.iterator():
+            if not phot.groups.filter(pk=public_group.pk).exists():
+                phot.groups.add(public_group)
+                tagged_phot += 1
+
+        tagged_spec = 0
+        for spec in spec_qs.iterator():
+            if not spec.groups.filter(pk=public_group.pk).exists():
+                spec.groups.add(public_group)
+                tagged_spec += 1
+
+        self.stdout.write(
+            self.style.SUCCESS(
+                f"Tagged {tagged_phot} photometry header(s) and {tagged_spec} spectrum(s) "
+                f"with {PUBLIC_COLLABORATION_GROUP_NAME!r}."
+            )
+        )

--- a/YSE_App/management/commands/seed_security_test_matrix.py
+++ b/YSE_App/management/commands/seed_security_test_matrix.py
@@ -1,0 +1,46 @@
+"""Seed four security-test users and secvis-matrix transient (mag-labeled photometry)."""
+
+from __future__ import annotations
+
+from django.core.management.base import BaseCommand
+
+from YSE_App.tests.fixtures_security_matrix import (
+    DEFAULT_TEST_PASSWORD,
+    EXPECTED_MAGS_BY_USER,
+    TEST_USERS,
+    TRANSIENT_NAME,
+    seed_security_test_matrix,
+)
+
+
+class Command(BaseCommand):
+    help = (
+        "Create security demo users (sec_user_ab, sec_user_ac, sec_user_b, sec_user_d) "
+        f"and transient {TRANSIENT_NAME} with mag-labeled photometry (0=public … 7=overlap)."
+    )
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--password",
+            default=DEFAULT_TEST_PASSWORD,
+            help=f"Password for test users (default: {DEFAULT_TEST_PASSWORD})",
+        )
+
+    def handle(self, *args, **options):
+        password = options["password"]
+        transient, users = seed_security_test_matrix(password=password)
+
+        self.stdout.write(self.style.SUCCESS("Security test matrix seeded."))
+        self.stdout.write("")
+        self.stdout.write(f"Transient: {transient.name} (slug: {transient.slug})")
+        self.stdout.write(f"URL: /transient_detail/{transient.slug}/")
+        self.stdout.write("")
+        self.stdout.write("Users (password: %s)" % password)
+        for username, group_keys in TEST_USERS:
+            groups = ", ".join(group_keys)
+            expected = sorted(EXPECTED_MAGS_BY_USER[username])
+            self.stdout.write(
+                f"  {username:14} groups={groups:8} expected LC mags: {expected}"
+            )
+        self.stdout.write("")
+        self.stdout.write("Log in at /login/ and open the transient URL above.")

--- a/YSE_App/management/commands/verify_production_group_access.py
+++ b/YSE_App/management/commands/verify_production_group_access.py
@@ -1,0 +1,38 @@
+"""Verify collaboration-group access against the live database (not the test DB)."""
+
+from __future__ import annotations
+
+from django.core.management.base import BaseCommand
+
+from YSE_App.services.group_access_checks import run_production_db_checks
+
+
+class Command(BaseCommand):
+    help = (
+        "Run production collaboration-group regression checks on the default database "
+        "(empty M2M semantics, tagged photometry, plot cache tokens). "
+        "Use after importing a server snapshot — not via manage.py test."
+    )
+
+    def handle(self, *args, **options):
+        results = run_production_db_checks()
+        failures = 0
+        skips = 0
+        for result in results:
+            if result.skipped:
+                skips += 1
+                self.stdout.write(f"SKIP {result.name}: {result.detail}")
+            elif result.passed:
+                self.stdout.write(self.style.SUCCESS(f"OK   {result.name}: {result.detail}"))
+            else:
+                failures += 1
+                self.stdout.write(self.style.ERROR(f"FAIL {result.name}: {result.detail}"))
+
+        if failures:
+            self.stdout.write(self.style.ERROR(f"\n{failures} check(s) failed."))
+            raise SystemExit(1)
+        self.stdout.write(
+            self.style.SUCCESS(
+                f"\nAll checks passed ({len(results) - skips - failures} ok, {skips} skipped)."
+            )
+        )

--- a/YSE_App/services/group_access_checks.py
+++ b/YSE_App/services/group_access_checks.py
@@ -1,0 +1,224 @@
+"""Shared checks for production collaboration-group access (tests + manage.py)."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List, Optional, Set
+
+from django.contrib.auth.models import Group, User
+from django.db.models import Count
+
+from YSE_App.data import PhotometryService
+from YSE_App.models import TransientPhotometry
+from YSE_App.services.visibility import group_access_plot_cache_token
+from YSE_App.tests.fixtures_production_groups import PRODUCTION_COLLABORATION_GROUPS
+
+
+@dataclass
+class CheckResult:
+    name: str
+    passed: bool
+    detail: str = ""
+    skipped: bool = False
+
+
+def check_production_groups_present(
+    minimum: int = 3,
+) -> CheckResult:
+    present: Set[str] = set(
+        Group.objects.filter(name__in=PRODUCTION_COLLABORATION_GROUPS).values_list(
+            "name", flat=True
+        )
+    )
+    if "Public" not in present:
+        return CheckResult(
+            "production_groups_present",
+            False,
+            f"'Public' missing; found {sorted(present)}",
+        )
+    if len(present) < minimum:
+        return CheckResult(
+            "production_groups_present",
+            False,
+            f"Expected >={minimum} production groups; found {sorted(present)}",
+        )
+    return CheckResult(
+        "production_groups_present",
+        True,
+        f"{len(present)} groups including Public",
+    )
+
+
+def check_empty_m2m_isnull_semantics() -> CheckResult:
+    by_count = TransientPhotometry.objects.annotate(gc=Count("groups")).filter(gc=0).count()
+    by_isnull = (
+        TransientPhotometry.objects.filter(groups__isnull=True).distinct().count()
+    )
+    if by_count == 0 and by_isnull == 0:
+        return CheckResult(
+            "empty_m2m_semantics",
+            True,
+            "No ungrouped photometry (skipped)",
+            skipped=True,
+        )
+    if by_count != by_isnull:
+        return CheckResult(
+            "empty_m2m_semantics",
+            False,
+            f"gc=0 count {by_count} != groups__isnull count {by_isnull}",
+        )
+    return CheckResult(
+        "empty_m2m_semantics",
+        True,
+        f"{by_count} ungrouped photometry rows (counts agree)",
+    )
+
+
+def check_ungrouped_visible_to_outsider(
+    outsider: Optional[User] = None,
+) -> CheckResult:
+    ungrouped = (
+        TransientPhotometry.objects.annotate(gc=Count("groups")).filter(gc=0).first()
+    )
+    if ungrouped is None:
+        return CheckResult(
+            "ungrouped_visible",
+            True,
+            "No ungrouped photometry (skipped)",
+            skipped=True,
+        )
+    if outsider is None:
+        outsider = User.objects.filter(is_superuser=False).first()
+    if outsider is None:
+        return CheckResult("ungrouped_visible", True, "No non-staff user (skipped)", skipped=True)
+
+    allowed = PhotometryService.GetAuthorizedTransientPhotometry_ByUser_ByTransient(
+        outsider,
+        ungrouped.transient_id,
+    )
+    ids = list(allowed.values_list("pk", flat=True))
+    if ungrouped.pk not in ids:
+        return CheckResult(
+            "ungrouped_visible",
+            False,
+            f"Ungrouped phot {ungrouped.pk} not visible to {outsider.username}",
+        )
+    return CheckResult(
+        "ungrouped_visible",
+        True,
+        f"Ungrouped phot {ungrouped.pk} visible to {outsider.username}",
+    )
+
+
+def check_tagged_photometry_restricted(
+    member: Optional[User] = None,
+    outsider: Optional[User] = None,
+) -> CheckResult:
+    tagged = (
+        TransientPhotometry.objects.annotate(gc=Count("groups"))
+        .filter(gc__gt=0)
+        .prefetch_related("groups")
+        .first()
+    )
+    if tagged is None:
+        return CheckResult(
+            "tagged_restricted",
+            True,
+            "No group-tagged photometry (skipped)",
+            skipped=True,
+        )
+
+    required = set(tagged.groups.values_list("name", flat=True))
+    if member is None:
+        member = User.objects.filter(groups__name__in=required).distinct().first()
+    if member is None:
+        return CheckResult(
+            "tagged_restricted",
+            True,
+            f"No user in {required} (skipped)",
+            skipped=True,
+        )
+    if outsider is None:
+        outsider = (
+            User.objects.filter(is_superuser=False)
+            .exclude(pk=member.pk)
+            .first()
+        )
+    if outsider is None:
+        return CheckResult("tagged_restricted", True, "No outsider user (skipped)", skipped=True)
+
+    outsider.groups.clear()
+    allowed_member = PhotometryService.GetAuthorizedTransientPhotometry_ByUser_ByTransient(
+        member, tagged.transient_id
+    )
+    allowed_outsider = PhotometryService.GetAuthorizedTransientPhotometry_ByUser_ByTransient(
+        outsider, tagged.transient_id
+    )
+    member_ids = set(allowed_member.values_list("pk", flat=True))
+    outsider_ids = set(allowed_outsider.values_list("pk", flat=True))
+    if tagged.pk not in member_ids:
+        return CheckResult(
+            "tagged_restricted",
+            False,
+            f"Tagged phot {tagged.pk} not visible to member {member.username}",
+        )
+    if tagged.pk in outsider_ids:
+        return CheckResult(
+            "tagged_restricted",
+            False,
+            f"Tagged phot {tagged.pk} visible to outsider {outsider.username} (groups {required})",
+        )
+    return CheckResult(
+        "tagged_restricted",
+        True,
+        f"Tagged phot {tagged.pk} restricted to groups {sorted(required)}",
+    )
+
+
+def check_plot_cache_token_by_groups_not_user() -> CheckResult:
+    from YSE_App.tests.fixtures_minimal import create_test_user
+
+    groups = Group.objects.filter(name__in=("YSE", "Public")).order_by("name")
+    if not groups.exists():
+        groups = Group.objects.all().order_by("name")[:2]
+    if groups.count() < 1:
+        return CheckResult(
+            "plot_cache_by_groups",
+            True,
+            "No groups in DB (skipped)",
+            skipped=True,
+        )
+
+    u1 = create_test_user("prodgrp_cache_check_1", is_staff=False)
+    u2 = create_test_user("prodgrp_cache_check_2", is_staff=False)
+    u1.groups.set(groups)
+    u2.groups.set(groups)
+    t1 = group_access_plot_cache_token(u1)
+    t2 = group_access_plot_cache_token(u2)
+    if t1 != t2:
+        return CheckResult(
+            "plot_cache_by_groups",
+            False,
+            f"Tokens differ for same groups: {t1} vs {t2}",
+        )
+    if str(u1.pk) in t1 or str(u2.pk) in t2:
+        return CheckResult(
+            "plot_cache_by_groups",
+            False,
+            f"Token appears to embed user id: {t1}",
+        )
+    return CheckResult(
+        "plot_cache_by_groups",
+        True,
+        f"Shared token {t1} for users {u1.pk}, {u2.pk}",
+    )
+
+
+def run_production_db_checks() -> List[CheckResult]:
+    return [
+        check_production_groups_present(),
+        check_empty_m2m_isnull_semantics(),
+        check_ungrouped_visible_to_outsider(),
+        check_tagged_photometry_restricted(),
+        check_plot_cache_token_by_groups_not_user(),
+    ]

--- a/YSE_App/services/visibility.py
+++ b/YSE_App/services/visibility.py
@@ -22,6 +22,29 @@ def user_group_names(user: User) -> List[str]:
     return list(user.groups.values_list("name", flat=True))
 
 
+def group_access_plot_cache_token(user: User) -> str:
+    """Cache suffix from collaboration-group membership (not user id).
+
+    Users who share the same set of ``auth.Group`` names receive the same token,
+    so plot HTML is reused across users with identical data access.
+    """
+    import hashlib
+
+    if not user.is_authenticated:
+        return "anon"
+    if user.is_staff or user.is_superuser:
+        return "staff"
+    names = sorted(user_group_names(user))
+    if not names:
+        return "nogroups"
+    digest = hashlib.sha256("|".join(names).encode()).hexdigest()[:12]
+    return f"g{digest}"
+
+
+# Backward-compatible alias (deprecated name).
+user_plot_cache_token = group_access_plot_cache_token
+
+
 def get_user_group_query(user: User):
     """Same semantics as PhotometryService: ungrouped OR intersects user groups."""
     names = user_group_names(user)

--- a/YSE_App/signals.py
+++ b/YSE_App/signals.py
@@ -1,0 +1,17 @@
+"""Django signals for YSE_App."""
+
+from __future__ import annotations
+
+from django.contrib.auth import get_user_model
+from django.db.models.signals import post_save
+from django.dispatch import receiver
+
+from YSE_App.common.collaboration_groups import ensure_user_has_public_group
+
+User = get_user_model()
+
+
+@receiver(post_save, sender=User, dispatch_uid="yse_ensure_user_public_group")
+def add_public_group_to_user(sender, instance, created, **kwargs):
+    """Every user belongs to the Public collaboration group."""
+    ensure_user_has_public_group(instance)

--- a/YSE_App/tests/fixtures_production_groups.py
+++ b/YSE_App/tests/fixtures_production_groups.py
@@ -1,0 +1,227 @@
+"""
+Production-style collaboration groups for visibility / plot-cache regression tests.
+
+Uses the same ``auth.Group`` names as the live YSE database (Public, YSE, UCSC, …),
+not the synthetic ``sec-group-*`` names from the security matrix demo.
+"""
+
+from __future__ import annotations
+
+import datetime
+from typing import Dict, Iterable, List, Optional, Sequence, Set, Tuple
+
+from django.contrib.auth.models import Group, User
+from django.utils import timezone
+
+from YSE_App.models import (
+    PhotometricBand,
+    Transient,
+    TransientPhotData,
+    TransientPhotometry,
+)
+from YSE_App.tests.fixtures_minimal import (
+    attach_synthetic_host,
+    audit_fields,
+    create_instrument_stack,
+    create_minimal_transient,
+    create_test_user,
+    ensure_transient_statuses,
+)
+
+# Names observed on production / scrubbed snapshots (see scrub_private_data.py).
+PRODUCTION_COLLABORATION_GROUPS: Tuple[str, ...] = (
+    "Public",
+    "YSE",
+    "UCSC",
+    "LCOGT",
+    "DEBASS",
+    "Foundation",
+    "K2",
+    "KITS",
+    "OUTSIDE",
+    "SIRAH",
+    "SOAR",
+    "SSS",
+    "TESS",
+)
+
+TRANSIENT_NAME = "prodgrp-vis-test"
+DEFAULT_TEST_PASSWORD = "prodgrp-test-pass"
+
+# Keys into PRODUCTION_COLLABORATION_GROUPS by short alias.
+GROUP_KEYS: Dict[str, str] = {
+    "public": "Public",
+    "yse": "YSE",
+    "ucsc": "UCSC",
+    "lcogt": "LCOGT",
+}
+
+# (mag label, group key tuple — empty = legacy ungrouped / world-readable in app)
+PHOTOMETRY_SERIES: Tuple[Tuple[int, Tuple[str, ...], str], ...] = (
+    (0, (), "legacy-public"),
+    (1, ("public",), "tagged-public"),
+    (2, ("yse",), "yse-only"),
+    (3, ("ucsc",), "ucsc-only"),
+    (4, ("lcogt",), "lcogt-only"),
+    (5, ("yse", "ucsc"), "yse-ucsc"),
+    (6, ("yse", "lcogt"), "yse-lcogt"),
+)
+
+TEST_USERS: Tuple[Tuple[str, Tuple[str, ...]], ...] = (
+    ("prod_user_pub_yse", ("public", "yse")),
+    ("prod_user_yse", ("yse",)),
+    ("prod_user_ucsc", ("ucsc",)),
+    ("prod_user_lcogt", ("lcogt",)),
+)
+
+EXPECTED_MAGS_BY_USER: Dict[str, Set[int]] = {
+    "prod_user_pub_yse": {0, 1, 2, 5, 6},
+    "prod_user_yse": {0, 2, 5, 6},
+    "prod_user_ucsc": {0, 3, 5},
+    "prod_user_lcogt": {0, 4, 6},
+}
+
+
+def ensure_production_groups(
+    names: Iterable[str] = PRODUCTION_COLLABORATION_GROUPS,
+) -> Dict[str, Group]:
+    """Get or create collaboration groups using production names."""
+    groups: Dict[str, Group] = {}
+    for name in names:
+        groups[name], _ = Group.objects.get_or_create(name=name)
+    return groups
+
+
+def _resolve_group_keys(
+    group_keys: Sequence[str],
+    groups_by_name: Dict[str, Group],
+) -> List[Group]:
+    resolved = []
+    for key in group_keys:
+        name = GROUP_KEYS[key]
+        resolved.append(groups_by_name[name])
+    return resolved
+
+
+def create_production_group_test_users(
+    *,
+    password: str = DEFAULT_TEST_PASSWORD,
+    groups_by_name: Optional[Dict[str, Group]] = None,
+) -> Dict[str, User]:
+    if groups_by_name is None:
+        groups_by_name = ensure_production_groups(
+            {GROUP_KEYS[k] for _, keys, _ in PHOTOMETRY_SERIES for k in keys}
+        )
+    users: Dict[str, User] = {}
+    for username, group_keys in TEST_USERS:
+        user = create_test_user(username, is_staff=False)
+        user.set_password(password)
+        user.save(update_fields=["password"])
+        user.groups.set(_resolve_group_keys(group_keys, groups_by_name))
+        users[username] = user
+    return users
+
+
+def _series_reference(mag: int) -> str:
+    return f"prodgrp-vis-mag-{mag}"
+
+
+def _attach_labeled_series(
+    admin: User,
+    transient: Transient,
+    *,
+    mag: int,
+    group_keys: Sequence[str],
+    band_suffix: str,
+    groups_by_name: Dict[str, Group],
+) -> TransientPhotometry:
+    audit = audit_fields(admin)
+    obs_group, instrument, _ = create_instrument_stack(
+        admin, obs_group_name=f"prodgrp-{band_suffix}"
+    )
+    band_name = f"r-{band_suffix}"
+    band, _ = PhotometricBand.objects.get_or_create(
+        name=band_name,
+        defaults={
+            "instrument": instrument,
+            "disp_color": "#DC143C",
+            "disp_symbol": "circle",
+            **audit,
+        },
+    )
+
+    reference = _series_reference(mag)
+    photometry, _ = TransientPhotometry.objects.update_or_create(
+        transient=transient,
+        reference=reference,
+        defaults={
+            "instrument": instrument,
+            "obs_group": obs_group,
+            **audit,
+        },
+    )
+    photometry.groups.clear()
+    for group in _resolve_group_keys(group_keys, groups_by_name):
+        photometry.groups.add(group)
+
+    obs_date = timezone.now() - datetime.timedelta(days=mag + 1)
+    TransientPhotData.objects.filter(photometry=photometry).delete()
+    TransientPhotData.objects.create(
+        photometry=photometry,
+        band=band,
+        obs_date=obs_date,
+        mag=float(mag),
+        mag_err=0.01,
+        discovery_point=(mag == 0),
+        **audit,
+    )
+    return photometry
+
+
+def create_production_group_vis_transient(admin: User) -> Transient:
+    ensure_transient_statuses(admin)
+    groups_by_name = ensure_production_groups(
+        {GROUP_KEYS[k] for _, keys, _ in PHOTOMETRY_SERIES for k in keys}
+    )
+    transient = create_minimal_transient(
+        admin,
+        name=TRANSIENT_NAME,
+        obs_group_name="prodgrp-survey",
+        ra=151.0,
+        dec=3.0,
+    )
+    attach_synthetic_host(admin, transient, name=f"host-{TRANSIENT_NAME}")
+
+    for mag, group_keys, band_suffix in PHOTOMETRY_SERIES:
+        _attach_labeled_series(
+            admin,
+            transient,
+            mag=mag,
+            group_keys=group_keys,
+            band_suffix=band_suffix,
+            groups_by_name=groups_by_name,
+        )
+    return transient
+
+
+def seed_production_group_vis_fixture(
+    *,
+    password: str = DEFAULT_TEST_PASSWORD,
+) -> Tuple[Transient, Dict[str, User]]:
+    admin = create_test_user("prodgrp_admin", is_staff=True)
+    users = create_production_group_test_users(password=password)
+    transient = create_production_group_vis_transient(admin)
+    return transient, users
+
+
+def authorized_mags_for_user(user: User, transient_id: int) -> Set[int]:
+    from YSE_App.data import PhotometryService
+
+    photdata = PhotometryService.GetAuthorizedTransientPhotData_ByUser_ByTransient(
+        user, transient_id, includeBadData=True
+    )
+    mags: Set[int] = set()
+    for row in photdata:
+        if row.mag is not None:
+            mags.add(int(round(float(row.mag))))
+    return mags

--- a/YSE_App/tests/fixtures_security_matrix.py
+++ b/YSE_App/tests/fixtures_security_matrix.py
@@ -1,0 +1,191 @@
+"""
+Security visibility demo: four users, one transient, mag-labeled photometry.
+
+Magnitude on each point equals its test ID (0 = public, 1 = group A only, …).
+"""
+
+from __future__ import annotations
+
+import datetime
+from typing import Dict, Iterable, List, Optional, Sequence, Set, Tuple
+
+from django.contrib.auth.models import Group, User
+from django.utils import timezone
+
+from YSE_App.models import (
+    PhotometricBand,
+    Transient,
+    TransientPhotData,
+    TransientPhotometry,
+)
+from YSE_App.tests.fixtures_minimal import (
+    attach_synthetic_host,
+    audit_fields,
+    create_instrument_stack,
+    create_minimal_transient,
+    create_test_user,
+    ensure_transient_statuses,
+)
+
+TRANSIENT_NAME = "secvis-matrix"
+DEFAULT_TEST_PASSWORD = "sec-test-pass"
+
+GROUP_NAMES = {
+    "a": "sec-group-a",
+    "b": "sec-group-b",
+    "c": "sec-group-c",
+    "d": "sec-group-d",
+}
+
+# (mag label, collaboration group keys, band suffix for legend)
+PHOTOMETRY_SERIES: Tuple[Tuple[int, Tuple[str, ...], str], ...] = (
+    (0, (), "public"),
+    (1, ("a",), "grpA"),
+    (2, ("b",), "grpB"),
+    (3, ("c",), "grpC"),
+    (4, ("d",), "grpD"),
+    (5, ("a", "b"), "grpAB"),
+    (6, ("a", "c"), "grpAC"),
+    (7, ("b", "c"), "grpBC"),
+)
+
+TEST_USERS: Tuple[Tuple[str, Tuple[str, ...]], ...] = (
+    ("sec_user_ab", ("a", "b")),
+    ("sec_user_ac", ("a", "c")),
+    ("sec_user_b", ("b",)),
+    ("sec_user_d", ("d",)),
+)
+
+# Expected magnitudes visible on the LC plot per test user.
+EXPECTED_MAGS_BY_USER: Dict[str, Set[int]] = {
+    "sec_user_ab": {0, 1, 2, 5, 6, 7},
+    "sec_user_ac": {0, 1, 3, 5, 6, 7},
+    "sec_user_b": {0, 2, 5, 7},
+    "sec_user_d": {0, 4},
+}
+
+
+def ensure_security_groups() -> Dict[str, Group]:
+    groups = {}
+    for key, name in GROUP_NAMES.items():
+        groups[key], _ = Group.objects.get_or_create(name=name)
+    return groups
+
+
+def create_security_test_users(
+    *,
+    password: str = DEFAULT_TEST_PASSWORD,
+) -> Dict[str, User]:
+    groups = ensure_security_groups()
+    users: Dict[str, User] = {}
+    for username, group_keys in TEST_USERS:
+        user = create_test_user(username, is_staff=False)
+        user.set_password(password)
+        user.save(update_fields=["password"])
+        user.groups.set([groups[k] for k in group_keys])
+        users[username] = user
+    return users
+
+
+def _series_reference(mag: int) -> str:
+    return f"secvis-matrix-mag-{mag}"
+
+
+def _attach_labeled_series(
+    admin: User,
+    transient: Transient,
+    *,
+    mag: int,
+    group_keys: Sequence[str],
+    band_suffix: str,
+    groups: Dict[str, Group],
+) -> TransientPhotometry:
+    audit = audit_fields(admin)
+    obs_group, instrument, _default_band = create_instrument_stack(
+        admin, obs_group_name=f"secvis-{band_suffix}"
+    )
+    band_name = f"r-{band_suffix}"
+    band, _ = PhotometricBand.objects.get_or_create(
+        name=band_name,
+        defaults={
+            "instrument": instrument,
+            "disp_color": "#DC143C",
+            "disp_symbol": "circle",
+            **audit,
+        },
+    )
+
+    reference = _series_reference(mag)
+    photometry, _ = TransientPhotometry.objects.update_or_create(
+        transient=transient,
+        reference=reference,
+        defaults={
+            "instrument": instrument,
+            "obs_group": obs_group,
+            **audit,
+        },
+    )
+    photometry.groups.clear()
+    for key in group_keys:
+        photometry.groups.add(groups[key])
+
+    obs_date = timezone.now() - datetime.timedelta(days=mag + 1)
+    TransientPhotData.objects.filter(photometry=photometry).delete()
+    TransientPhotData.objects.create(
+        photometry=photometry,
+        band=band,
+        obs_date=obs_date,
+        mag=float(mag),
+        mag_err=0.01,
+        discovery_point=(mag == 0),
+        **audit,
+    )
+    return photometry
+
+
+def create_secvis_matrix_transient(admin: User) -> Transient:
+    """Idempotent: one transient with mag-labeled public/private photometry."""
+    ensure_transient_statuses(admin)
+    groups = ensure_security_groups()
+    transient = create_minimal_transient(
+        admin,
+        name=TRANSIENT_NAME,
+        obs_group_name="secvis-matrix-survey",
+        ra=150.0,
+        dec=2.5,
+    )
+    attach_synthetic_host(admin, transient, name=f"host-{TRANSIENT_NAME}")
+
+    for mag, group_keys, band_suffix in PHOTOMETRY_SERIES:
+        _attach_labeled_series(
+            admin,
+            transient,
+            mag=mag,
+            group_keys=group_keys,
+            band_suffix=band_suffix,
+            groups=groups,
+        )
+    return transient
+
+
+def seed_security_test_matrix(
+    *,
+    password: str = DEFAULT_TEST_PASSWORD,
+) -> Tuple[Transient, Dict[str, User]]:
+    admin = create_test_user("sec_admin", is_staff=True)
+    users = create_security_test_users(password=password)
+    transient = create_secvis_matrix_transient(admin)
+    return transient, users
+
+
+def authorized_mags_for_user(user: User, transient_id: int) -> Set[int]:
+    from YSE_App.data import PhotometryService
+
+    photdata = PhotometryService.GetAuthorizedTransientPhotData_ByUser_ByTransient(
+        user, transient_id, includeBadData=True
+    )
+    mags: Set[int] = set()
+    for row in photdata:
+        if row.mag is not None:
+            mags.add(int(round(float(row.mag))))
+    return mags

--- a/YSE_App/tests/test_production_group_access.py
+++ b/YSE_App/tests/test_production_group_access.py
@@ -1,0 +1,173 @@
+"""
+Regression tests for collaboration-group access using production group names.
+
+Covers legacy ungrouped photometry (empty M2M), ``Public``-tagged rows, and
+restricted groups (YSE, UCSC, LCOGT) as on the server database — plus plot-cache
+keys derived from group membership, not user id.
+"""
+
+from __future__ import annotations
+
+import os
+import unittest
+
+from django.contrib.auth.models import Group
+from django.core.cache import cache
+from django.test import Client, TestCase
+from django.urls import reverse
+
+from YSE_App.models import TransientPhotometry
+from YSE_App.services.group_access_checks import run_production_db_checks
+from YSE_App.services.visibility import (
+    get_user_group_query,
+    group_access_plot_cache_token,
+)
+from YSE_App.tests.fixtures_minimal import create_test_user
+from YSE_App.tests.fixtures_production_groups import (
+    EXPECTED_MAGS_BY_USER,
+    GROUP_KEYS,
+    PHOTOMETRY_SERIES,
+    TRANSIENT_NAME,
+    authorized_mags_for_user,
+    seed_production_group_vis_fixture,
+)
+
+
+class ProductionGroupPatternTests(TestCase):
+    """Synthetic transient using real production ``auth.Group`` names."""
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.transient, cls.users = seed_production_group_vis_fixture()
+
+    def test_production_group_names_exist(self):
+        for name in {GROUP_KEYS[k] for _, keys, _ in PHOTOMETRY_SERIES for k in keys}:
+            self.assertTrue(Group.objects.filter(name=name).exists(), name)
+
+    def test_legacy_ungrouped_photometry_visible_to_all_test_users(self):
+        """Empty ``groups`` M2M (server default for public data) — all users see mag 0."""
+        for username, user in self.users.items():
+            with self.subTest(user=username):
+                mags = authorized_mags_for_user(user, self.transient.id)
+                self.assertIn(0, mags)
+
+    def test_public_tagged_row_requires_public_group_membership(self):
+        """``Public`` collaboration group (scrub script), not the same as empty M2M."""
+        yse_only = self.users["prod_user_yse"]
+        pub_yse = self.users["prod_user_pub_yse"]
+        self.assertNotIn(1, authorized_mags_for_user(yse_only, self.transient.id))
+        self.assertIn(1, authorized_mags_for_user(pub_yse, self.transient.id))
+
+    def test_authorized_mags_per_user(self):
+        for username, expected in EXPECTED_MAGS_BY_USER.items():
+            user = self.users[username]
+            with self.subTest(user=username):
+                self.assertEqual(
+                    authorized_mags_for_user(user, self.transient.id),
+                    expected,
+                )
+
+    def test_get_user_group_query_uses_production_group_names(self):
+        user = self.users["prod_user_pub_yse"]
+        no_group, contains_group = get_user_group_query(user)
+        qs = TransientPhotometry.objects.filter(
+            transient_id=self.transient.id,
+        ).filter(no_group | contains_group)
+        mags = set()
+        for phot in qs:
+            for pd in phot.transientphotdata_set.all():
+                if pd.mag is not None:
+                    mags.add(int(round(float(pd.mag))))
+        self.assertEqual(mags, EXPECTED_MAGS_BY_USER["prod_user_pub_yse"])
+
+    def test_plot_cache_token_same_for_same_production_groups_different_users(self):
+        twin = create_test_user("prod_user_pub_yse_twin", is_staff=False)
+        twin.groups.set(self.users["prod_user_pub_yse"].groups.all())
+        self.assertNotEqual(
+            self.users["prod_user_pub_yse"].pk,
+            twin.pk,
+        )
+        self.assertEqual(
+            group_access_plot_cache_token(self.users["prod_user_pub_yse"]),
+            group_access_plot_cache_token(twin),
+        )
+
+    def test_plot_cache_token_differs_for_different_production_group_sets(self):
+        tokens = {
+            username: group_access_plot_cache_token(user)
+            for username, user in self.users.items()
+        }
+        self.assertEqual(len(tokens), len(set(tokens.values())))
+
+    def test_plot_cache_token_does_not_encode_user_id(self):
+        token = group_access_plot_cache_token(self.users["prod_user_yse"])
+        self.assertNotIn(str(self.users["prod_user_yse"].pk), token)
+
+    def test_lightcurve_plot_not_shared_across_production_group_sets(self):
+        url = reverse(
+            "lightcurveplot_detail",
+            kwargs={"transient_id": self.transient.id},
+        )
+        client = Client()
+        client.force_login(self.users["prod_user_pub_yse"])
+        pub_yse_html = client.get(url).content
+        client.force_login(self.users["prod_user_ucsc"])
+        ucsc_html = client.get(url).content
+        self.assertNotEqual(pub_yse_html, ucsc_html)
+
+    def test_lightcurve_plot_cache_hit_for_same_production_group_membership(self):
+        """Two users in Public+YSE must share cached plot HTML (not per-user cache)."""
+        url = reverse(
+            "lightcurveplot_detail",
+            kwargs={"transient_id": self.transient.id},
+        )
+        twin = create_test_user("prod_user_pub_yse_cache_twin", is_staff=False)
+        twin.groups.set(self.users["prod_user_pub_yse"].groups.all())
+        self.assertEqual(
+            group_access_plot_cache_token(self.users["prod_user_pub_yse"]),
+            group_access_plot_cache_token(twin),
+        )
+
+        cache.clear()
+        client = Client()
+        client.force_login(self.users["prod_user_pub_yse"])
+        first = client.get(url).content
+        client.force_login(twin)
+        second = client.get(url).content
+        self.assertEqual(first, second)
+        self.assertTrue(first)
+
+
+class ProductionDbCheckLogicTests(TestCase):
+    """Unit tests for shared check helpers (used by verify_production_group_access)."""
+
+    def test_run_production_db_checks_on_synthetic_fixture(self):
+        seed_production_group_vis_fixture()
+        results = run_production_db_checks()
+        failed = [r for r in results if not r.passed and not r.skipped]
+        self.assertEqual(failed, [], [f"{r.name}: {r.detail}" for r in failed])
+
+
+@unittest.skipUnless(
+    os.environ.get("YSE_TEST_EXISTING_DB_GROUPS", "0") == "1",
+    "Set YSE_TEST_EXISTING_DB_GROUPS=1 to mirror checks on default DB via test runner.",
+)
+class ExistingDatabaseCollaborationGroupTests(TestCase):
+    """
+    Delegates to the same checks as ``verify_production_group_access``.
+
+    Prefer the management command on the **default** database (server snapshot):
+
+      docker exec ysepz_web_container python3 manage.py verify_production_group_access
+    """
+
+    databases = {"default"}
+
+    def test_live_database_group_regression(self):
+        results = run_production_db_checks()
+        failures = [r for r in results if not r.passed and not r.skipped]
+        self.assertEqual(
+            failures,
+            [],
+            "\n".join(f"{r.name}: {r.detail}" for r in failures),
+        )

--- a/YSE_App/tests/test_public_group_membership.py
+++ b/YSE_App/tests/test_public_group_membership.py
@@ -1,0 +1,53 @@
+"""Tests that every user belongs to the Public collaboration group."""
+
+from __future__ import annotations
+
+from django.contrib.auth import get_user_model
+from django.core.management import call_command
+from django.test import TestCase
+
+from YSE_App.common.collaboration_groups import (
+    PUBLIC_COLLABORATION_GROUP_NAME,
+    ensure_user_has_public_group,
+)
+from YSE_App.tests.fixtures_minimal import create_test_user
+
+User = get_user_model()
+
+
+class PublicGroupMembershipTests(TestCase):
+    def test_new_user_automatically_gets_public_group(self):
+        user = User.objects.create_user(
+            username="public_auto_user",
+            email="public_auto@example.com",
+            password="test-pass",
+        )
+        self.assertTrue(
+            user.groups.filter(name=PUBLIC_COLLABORATION_GROUP_NAME).exists()
+        )
+
+    def test_ensure_user_has_public_group_is_idempotent(self):
+        user = create_test_user("public_idempotent_user", is_staff=False)
+        self.assertTrue(
+            user.groups.filter(name=PUBLIC_COLLABORATION_GROUP_NAME).exists()
+        )
+        self.assertFalse(ensure_user_has_public_group(user))
+
+    def test_ensure_users_in_public_group_backfills_missing_membership(self):
+        user = User.objects.create_user(
+            username="public_backfill_user",
+            email="public_backfill@example.com",
+            password="test-pass",
+        )
+        public_group = user.groups.get(name=PUBLIC_COLLABORATION_GROUP_NAME)
+        user.groups.remove(public_group)
+        self.assertFalse(
+            user.groups.filter(name=PUBLIC_COLLABORATION_GROUP_NAME).exists()
+        )
+
+        call_command("ensure_users_in_public_group")
+
+        user.refresh_from_db()
+        self.assertTrue(
+            user.groups.filter(name=PUBLIC_COLLABORATION_GROUP_NAME).exists()
+        )

--- a/YSE_App/tests/test_security_matrix.py
+++ b/YSE_App/tests/test_security_matrix.py
@@ -1,0 +1,96 @@
+"""Security matrix: four users × mag-labeled photometry on secvis-matrix."""
+
+from django.test import Client, TestCase
+from django.urls import reverse
+
+from YSE_App.data import PhotometryService
+from YSE_App.services.visibility import group_access_plot_cache_token, user_can_view_transient
+from YSE_App.tests.fixtures_security_matrix import (
+    EXPECTED_MAGS_BY_USER,
+    TRANSIENT_NAME,
+    authorized_mags_for_user,
+    seed_security_test_matrix,
+)
+
+
+class SecurityMatrixPhotometryTests(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.transient, cls.users = seed_security_test_matrix()
+
+    def test_transient_name(self):
+        self.assertEqual(self.transient.name, TRANSIENT_NAME)
+
+    def test_all_users_can_view_transient_via_public_photometry(self):
+        for username, user in self.users.items():
+            with self.subTest(user=username):
+                self.assertTrue(
+                    user_can_view_transient(user, self.transient.id),
+                    f"{username} should access transient (public mag 0)",
+                )
+
+    def test_authorized_mags_per_user(self):
+        for username, expected in EXPECTED_MAGS_BY_USER.items():
+            user = self.users[username]
+            with self.subTest(user=username):
+                mags = authorized_mags_for_user(user, self.transient.id)
+                self.assertEqual(mags, expected)
+
+    def test_photometry_series_count_per_user(self):
+        for username, expected in EXPECTED_MAGS_BY_USER.items():
+            user = self.users[username]
+            with self.subTest(user=username):
+                phot = PhotometryService.GetAuthorizedTransientPhotometry_ByUser_ByTransient(
+                    user, self.transient.id
+                )
+                self.assertEqual(phot.count(), len(expected))
+
+    def test_user_d_does_not_see_restricted_series(self):
+        user = self.users["sec_user_d"]
+        mags = authorized_mags_for_user(user, self.transient.id)
+        self.assertNotIn(1, mags)
+        self.assertNotIn(5, mags)
+        self.assertIn(0, mags)
+        self.assertIn(4, mags)
+
+    def test_plot_cache_token_differs_by_user_groups(self):
+        ab = group_access_plot_cache_token(self.users["sec_user_ab"])
+        b = group_access_plot_cache_token(self.users["sec_user_b"])
+        d = group_access_plot_cache_token(self.users["sec_user_d"])
+        self.assertNotEqual(ab, b)
+        self.assertNotEqual(ab, d)
+
+    def test_plot_cache_token_same_for_identical_group_membership(self):
+        from django.contrib.auth.models import Group
+
+        from YSE_App.tests.fixtures_minimal import create_test_user
+
+        twin = create_test_user("sec_user_ab_twin", is_staff=False)
+        twin.groups.set(
+            Group.objects.filter(
+                name__in=["sec-group-a", "sec-group-b"],
+            )
+        )
+        self.assertEqual(
+            group_access_plot_cache_token(self.users["sec_user_ab"]),
+            group_access_plot_cache_token(twin),
+        )
+        self.assertNotEqual(
+            group_access_plot_cache_token(twin),
+            group_access_plot_cache_token(self.users["sec_user_b"]),
+        )
+
+    def test_lightcurve_plot_html_differs_by_user(self):
+        url = reverse("lightcurveplot_detail", kwargs={"transient_id": self.transient.id})
+        client = Client()
+        client.force_login(self.users["sec_user_ab"])
+        ab_html = client.get(url).content
+        client.force_login(self.users["sec_user_b"])
+        b_html = client.get(url).content
+        client.force_login(self.users["sec_user_d"])
+        d_html = client.get(url).content
+        self.assertNotEqual(ab_html, b_html)
+        self.assertNotEqual(ab_html, d_html)
+        self.assertTrue(ab_html)
+        self.assertTrue(b_html)
+        self.assertTrue(d_html)

--- a/YSE_App/tests/test_tns_import_groups.py
+++ b/YSE_App/tests/test_tns_import_groups.py
@@ -1,0 +1,201 @@
+"""Tests that TNS ingest tags photometry and spectra with the Public collaboration group."""
+
+from __future__ import annotations
+
+import json
+from unittest import mock
+
+from django.contrib.auth.models import Group
+from django.test import Client, TestCase
+
+from YSE_App.common.collaboration_groups import (
+    PUBLIC_COLLABORATION_GROUP_NAME,
+    TNS_IMPORT_COLLABORATION_GROUPS,
+    collaboration_groups_from_photometry_upload,
+)
+from YSE_App.data_ingest.TNS_uploads import processTNS
+from YSE_App.data_utils import add_transient_phot_util, add_transient_spec_util
+from YSE_App.models import Transient, TransientPhotometry, TransientSpectrum
+from YSE_App.tests.fixtures_minimal import (
+    create_instrument_stack,
+    create_minimal_transient,
+    create_test_user,
+    ensure_transient_statuses,
+)
+
+
+def _sample_tns_photometry_json():
+    return {
+        "photometry": [
+            {
+                "instrument": {"name": "ZTF-Cam"},
+                "filters": {"name": "r"},
+                "flux_unit": {"name": "ABMag"},
+                "flux": 18.5,
+                "fluxerr": 0.1,
+                "obsdate": "2026-06-01 12:00:00",
+                "observer": "ZTF",
+            },
+            {
+                "instrument": {"name": "ATLAS-05"},
+                "filters": {"name": "orange-ATLAS"},
+                "flux_unit": {"name": "ABMag"},
+                "flux": 19.0,
+                "fluxerr": 0.2,
+                "obsdate": "2026-06-02 08:00:00",
+                "observer": "ATLAS",
+            },
+        ],
+        "spectra": [],
+    }
+
+
+class TnsImportGroupConstantsTests(TestCase):
+    def test_tns_import_groups_use_public(self):
+        self.assertEqual(
+            list(TNS_IMPORT_COLLABORATION_GROUPS),
+            [PUBLIC_COLLABORATION_GROUP_NAME],
+        )
+
+
+class TnsPhotometryUploadShapeTests(TestCase):
+    def test_get_tns_photometry_marks_public_on_header_and_points(self):
+        proc = processTNS()
+        proc.clobber = True
+        phot, *_ = proc.getTNSPhotometry(_sample_tns_photometry_json())
+
+        for block in phot.values():
+            if not isinstance(block, dict) or "photdata" not in block:
+                continue
+            self.assertEqual(block.get("groups"), list(TNS_IMPORT_COLLABORATION_GROUPS))
+            for point in block["photdata"].values():
+                self.assertEqual(point.get("groups"), list(TNS_IMPORT_COLLABORATION_GROUPS))
+
+
+class TnsImportGroupsPersistTests(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.admin = create_test_user("tns_grp_admin", is_staff=True)
+        ensure_transient_statuses(cls.admin)
+        Group.objects.get_or_create(name=PUBLIC_COLLABORATION_GROUP_NAME)
+        cls.transient = create_minimal_transient(
+            cls.admin,
+            name="2026tgrp",
+            obs_group_name="tns-test-survey",
+        )
+        cls.obs_group, cls.instrument, cls.band = create_instrument_stack(
+            cls.admin,
+            obs_group_name="ZTF",
+        )
+
+    def test_add_transient_phot_util_applies_public_from_tns_upload(self):
+        photdict = {
+            "mjdmatchmin": 0.01,
+            "clobber": True,
+            0: {
+                "instrument": self.instrument.name,
+                "obs_group": self.obs_group.name,
+                "groups": list(TNS_IMPORT_COLLABORATION_GROUPS),
+                "photdata": {
+                    "pt1": {
+                        "obs_date": "2026-06-01T12:00:00",
+                        "band": self.band.name,
+                        "groups": list(TNS_IMPORT_COLLABORATION_GROUPS),
+                        "mag": 18.5,
+                        "mag_err": 0.1,
+                        "flux": None,
+                        "flux_err": None,
+                        "forced": None,
+                        "diffim": None,
+                        "flux_zero_point": None,
+                        "data_quality": 0,
+                        "discovery_point": 1,
+                    },
+                },
+            },
+        }
+        _, phot_entries = add_transient_phot_util(
+            photdict, self.transient, self.admin, do_photdata=False
+        )
+        TransientPhotometry.objects.bulk_create(phot_entries)
+        add_transient_phot_util(photdict, self.transient, self.admin, do_photdata=True)
+
+        phot = TransientPhotometry.objects.get(transient=self.transient)
+        self.assertEqual(
+            set(phot.groups.values_list("name", flat=True)),
+            {PUBLIC_COLLABORATION_GROUP_NAME},
+        )
+
+    def test_add_transient_via_http_marks_tns_photometry_public(self):
+        proc = processTNS()
+        proc.clobber = True
+        phot, *_ = proc.getTNSPhotometry(_sample_tns_photometry_json())
+
+        payload = {
+            self.transient.name: {
+                "name": self.transient.name,
+                "ra": self.transient.ra,
+                "dec": self.transient.dec,
+                "status": "New",
+                "obs_group": self.transient.obs_group.name,
+                "transientphotometry": phot,
+            },
+            "TNS": True,
+        }
+
+        client = Client()
+        client.force_login(self.admin)
+        with mock.patch(
+            "YSE_App.data_utils.auth.authenticate",
+            return_value=self.admin,
+        ):
+            response = client.post(
+                "/add_transient/",
+                data=json.dumps(payload),
+                content_type="application/json",
+                HTTP_AUTHORIZATION="Basic dGVzdDp0ZXN0",
+            )
+        self.assertEqual(response.status_code, 200, response.content)
+
+        names = set(
+            TransientPhotometry.objects.filter(transient=self.transient)
+            .values_list("groups__name", flat=True)
+            .distinct()
+        )
+        names.discard(None)
+        self.assertEqual(names, {PUBLIC_COLLABORATION_GROUP_NAME})
+
+    def test_collaboration_groups_from_photometry_upload_reads_per_point_groups(self):
+        photometry = {
+            "photdata": {
+                "a": {"groups": ["Public"]},
+                "b": {"groups": ["Public"]},
+            },
+        }
+        self.assertEqual(
+            collaboration_groups_from_photometry_upload(photometry),
+            ["Public"],
+        )
+
+    def test_add_transient_spec_util_applies_public_from_tns_upload(self):
+        specdict = {
+            "clobber": True,
+            "spec1": {
+                "instrument": self.instrument.name,
+                "obs_group": self.obs_group.name,
+                "obs_date": "2026-06-01T12:00:00",
+                "ra": self.transient.ra,
+                "dec": self.transient.dec,
+                "groups": PUBLIC_COLLABORATION_GROUP_NAME,
+                "specdata": {
+                    5000.0: {"wavelength": 5000.0, "flux": 1.0, "flux_err": 0.1},
+                },
+            },
+        }
+        add_transient_spec_util(specdict, self.transient, self.admin)
+
+        spec = TransientSpectrum.objects.get(transient=self.transient)
+        self.assertEqual(
+            set(spec.groups.values_list("name", flat=True)),
+            {PUBLIC_COLLABORATION_GROUP_NAME},
+        )

--- a/YSE_App/view_utils.py
+++ b/YSE_App/view_utils.py
@@ -32,6 +32,7 @@ from .common.filter_display import (
     telescope_display_symbol,
 )
 from .common.utilities import date_to_mjd
+from .services.visibility import group_access_plot_cache_token
 
 import copy
 import functools
@@ -979,7 +980,10 @@ def lightcurveplot_detail(request, transient_id, salt2=False):
 
     cache_key = None
     if not salt2 and _plot_html_cache_enabled():
-        cache_key = f'lc_detail_v4_{transient_id}_{_transient_phot_cache_token(transient_id)}'
+        user_key = group_access_plot_cache_token(request.user)
+        cache_key = (
+            f'lc_detail_v5_{transient_id}_{_transient_phot_cache_token(transient_id)}_{user_key}'
+        )
         cached_html = cache.get(cache_key)
         if cached_html is not None:
             return django.http.HttpResponse(cached_html)
@@ -1582,7 +1586,10 @@ def spectrumplot(request, transient_id):
 
     cache_key = None
     if _plot_html_cache_enabled():
-        cache_key = f'specplot_v1_{transient_id}_{_transient_spectrum_cache_token(transient_id)}'
+        user_key = group_access_plot_cache_token(request.user)
+        cache_key = (
+            f'specplot_v2_{transient_id}_{_transient_spectrum_cache_token(transient_id)}_{user_key}'
+        )
         cached_html = cache.get(cache_key)
         if cached_html is not None:
             return django.http.HttpResponse(cached_html)

--- a/docs/security-groups.md
+++ b/docs/security-groups.md
@@ -5,6 +5,7 @@ YSE uses Django **collaboration groups** (`auth.Group`) on photometry, spectra, 
 ## Rules
 
 - **Empty `groups` M2M** on photometry/spectra/resources: visible to all logged-in users (unchanged).
+- **Every user** is a member of the `Public` collaboration group (signal on user create + `ensure_users_in_public_group` for backfill).
 - **New transient comments**: private by default (`Log.is_public=False` with `Log.groups` set to shared collaboration groups). Opt-in `is_public=True` for all collaborators who can open the transient.
 - **Legacy comments** (before migration `0005_log_visibility`): `is_public=True`, no groups — unchanged visibility.
 - **Follow-up requests** (`TransientFollowup`): default **public** (`is_public=True`). Restrict with `is_public=False` and optional `groups` M2M; `requested_by` is set on create.
@@ -17,6 +18,61 @@ YSE uses Django **collaboration groups** (`auth.Group`) on photometry, spectra, 
 ## SQL Explorer
 
 Staff-only (`EXPLORER_PERMISSION_VIEW` / `CHANGE` in settings). Dashboard and canvas SQL results are post-filtered with `filter_transients_by_user_access`.
+
+## Manual test matrix
+
+Seed demo users and a labeled transient for browser testing:
+
+```bash
+docker exec ysepz_web_container python3 manage.py seed_security_test_matrix
+```
+
+| User | Password | Groups | Expected LC magnitudes |
+|------|----------|--------|------------------------|
+| `sec_user_ab` | `sec-test-pass` | A, B | 0, 1, 2, 5, 6, 7 |
+| `sec_user_ac` | `sec-test-pass` | A, C | 0, 1, 3, 5, 6, 7 |
+| `sec_user_b` | `sec-test-pass` | B | 0, 2, 5, 7 |
+| `sec_user_d` | `sec-test-pass` | D | 0, 4 |
+
+Transient **`secvis-matrix`**: each photometry point’s magnitude equals its test ID (0 = public, 1 = group A only, …, 7 = groups B+C). Open `/transient_detail/secvis-matrix/` after logging in.
+
+Fixture code: [`YSE_App/tests/fixtures_security_matrix.py`](../YSE_App/tests/fixtures_security_matrix.py). Automated checks: [`test_security_matrix.py`](../YSE_App/tests/test_security_matrix.py).
+
+### TNS ingest
+
+TNS photometry and spectra are tagged with the `Public` collaboration group on import
+(`YSE_App/common/collaboration_groups.py`, `TNS_uploads.getTNSPhotometry` / `getTNSSpectra`).
+
+Backfill legacy ungrouped TNS rows on a server snapshot:
+
+```bash
+docker exec ysepz_web_container python3 manage.py mark_tns_imports_public --dry-run
+docker exec ysepz_web_container python3 manage.py mark_tns_imports_public
+```
+
+Tests: `YSE_App.tests.test_tns_import_groups`.
+
+Backfill existing users on a server snapshot:
+
+```bash
+docker exec ysepz_web_container python3 manage.py ensure_users_in_public_group --dry-run
+docker exec ysepz_web_container python3 manage.py ensure_users_in_public_group
+```
+
+### Production group names (regression)
+
+Tests use the same collaboration group names as the server (`Public`, `YSE`, `UCSC`, `LCOGT`, …) — see [`fixtures_production_groups.py`](../YSE_App/tests/fixtures_production_groups.py) and [`test_production_group_access.py`](../YSE_App/tests/test_production_group_access.py).
+
+```bash
+# Always run (synthetic transient prodgrp-vis-test)
+docker exec ysepz_web_container python3 manage.py test \
+  YSE_App.tests.test_production_group_access.ProductionGroupPatternTests --keepdb -v2
+
+# After importing a production DB snapshot (validates on the **default** DB, not test DB):
+docker exec ysepz_web_container python3 manage.py verify_production_group_access
+```
+
+Plot HTML cache keys use `group_access_plot_cache_token()` — a hash of sorted group names, not user id.
 
 ## Remaining ([#102](https://github.com/Young-Supernova-Experiment/YSE_PZ/issues/102))
 


### PR DESCRIPTION
## Summary

- Fix plot HTML cache leaking across users with different collaboration groups: LC plots use `lc_detail_v5_*` and spectra use `specplot_v2_*`, keyed by `group_access_plot_cache_token()` (hash of sorted `auth.Group` names, not user id).
- Tag TNS-imported photometry and spectra with the `Public` collaboration group; fix `add_transient_phot_util` so upload JSON `groups` are actually persisted on `TransientPhotometry`.
- Ensure every user belongs to `Public` (post-save signal + `ensure_users_in_public_group` backfill command).
- Add regression tests and ops tooling: security matrix (`secvis-matrix`), production group-name fixtures (`Public`, `YSE`, `UCSC`, …), and `verify_production_group_access` for server DB snapshots.

Part of [#102](https://github.com/Young-Supernova-Experiment/YSE_PZ/issues/102). Does **not** include comment/follow-up create-time audience UI, DRF hardening, or Group Slack ([#100](https://github.com/Young-Supernova-Experiment/YSE_PZ/issues/100)) — follow-up PRs.

Docs: [`docs/security-groups.md`](docs/security-groups.md)

---

## Before merge (reviewer / staging)

### 1. Run automated tests

```bash
docker exec ysepz_web_container python3 manage.py test \
  YSE_App.tests.test_security_matrix \
  YSE_App.tests.test_production_group_access \
  YSE_App.tests.test_tns_import_groups \
  YSE_App.tests.test_public_group_membership \
  YSE_App.tests.test_group_visibility \
  --keepdb -v2
```

Full CI-equivalent suite:

```bash
docker exec ysepz_web_container python3 manage.py test YSE_App.tests --keepdb -v1
```

### 2. Seed the browser test matrix (optional, on staging DB)

```bash
docker exec ysepz_web_container python3 manage.py seed_security_test_matrix
```

| User | Password | Expected LC mags on `secvis-matrix` |
|------|----------|-------------------------------------|
| `sec_user_ab` | `sec-test-pass` | 0, 1, 2, 5, 6, 7 |
| `sec_user_b` | `sec-test-pass` | 0, 2, 5, 7 |
| `sec_user_d` | `sec-test-pass` | 0, 4 |

Open `/transient_detail/secvis-matrix/` after login. **Hard-refresh** (plot cache). Confirm `sec_user_b` and `sec_user_ab` see **different** light curves (regression for the original cache bug).

### 3. Dry-run production checks (if staging has a server DB import)

```bash
docker exec ysepz_web_container python3 manage.py verify_production_group_access
docker exec ysepz_web_container python3 manage.py ensure_users_in_public_group --dry-run
docker exec ysepz_web_container python3 manage.py mark_tns_imports_public --dry-run
```

---

## After merge (production server)

Run these on the **live server** after deploying the new code (adjust container/host names to match production).

### Step 1 — Deploy code and restart web

```bash
# Example; use your normal deploy process
git pull origin develop
docker compose restart web   # or equivalent service restart
```

### Step 2 — Backfill user `Public` membership

Every user must be in the `Public` group so they can see TNS-tagged data.

```bash
# Preview counts first
python3 manage.py ensure_users_in_public_group --dry-run

# Apply
python3 manage.py ensure_users_in_public_group
```

Expected: adds `Public` to any user missing it. Safe to re-run (idempotent).

### Step 3 — Backfill TNS photometry/spectra as `Public`

Legacy TNS rows were imported with empty `groups` M2M. Tag them explicitly:

```bash
# Preview counts first
python3 manage.py mark_tns_imports_public --dry-run

# Apply
python3 manage.py mark_tns_imports_public
```

Targets photometry/spectra on TNS-named transients (`2026fba`, etc.) that have no collaboration groups yet.

### Step 4 — Verify production group semantics

```bash
python3 manage.py verify_production_group_access
```

Should report all checks passed (production group names present, empty-M2M semantics, plot-cache token by groups not user id).

### Step 5 — Clear plot HTML cache (recommended)

Cache keys changed (`lc_detail_v4` → `lc_detail_v5`, `specplot_v1` → `specplot_v2`). Restarting web/Django cache or flushing Redis/Memcached avoids stale cross-user plot HTML:

```bash
docker compose restart web
# If using a persistent cache backend, flush it once after deploy
```

### Step 6 — Smoke test on a real transient

1. Log in as a non-staff user with `YSE` (or another restricted group).
2. Open a transient with mixed public/restricted photometry.
3. Confirm the light curve shows only authorized points.
4. Log in as a second user with different groups; confirm a different plot (not a cached copy of the first user's plot).

### Ongoing (no manual step)

- New users automatically receive `Public` via Django signal.
- New TNS cron imports tag photometry/spectra as `Public` automatically.

---

## Test plan

- [x] `YSE_App.tests` (131 tests) pass locally
- [x] Security matrix tests (`test_security_matrix`)
- [x] Production group name tests (`test_production_group_access`)
- [x] TNS `Public` tagging tests (`test_tns_import_groups`)
- [x] User `Public` membership tests (`test_public_group_membership`)
- [ ] Manual: `secvis-matrix` browser check (see above)
- [ ] Post-deploy: `ensure_users_in_public_group` + `mark_tns_imports_public` + `verify_production_group_access` on server


Made with [Cursor](https://cursor.com)