### PR TITLE
v1 create-time audience UI for comments and follow-ups

### DIFF
--- a/YSE_App/api_views.py
+++ b/YSE_App/api_views.py
@@ -523,14 +523,24 @@ class TransientCommentListCreate(generics.ListCreateAPIView):
         return transient_comment_queryset(transient_id, user=self.request.user)
 
     def create(self, request, *args, **kwargs):
+        from YSE_App.services.audience import resolve_comment_audience
         from YSE_App.services.comments import create_transient_comment
 
         serializer = self.get_serializer(data=request.data)
         serializer.is_valid(raise_exception=True)
+        transient = serializer.validated_data["transient"]
+        is_public, audience_groups = resolve_comment_audience(
+            request.user,
+            transient.id,
+            is_public=serializer.validated_data.get("is_public", False),
+            audience_group_ids=serializer.validated_data.get("audience_group_ids"),
+        )
         log = create_transient_comment(
-            transient=serializer.validated_data["transient"],
+            transient=transient,
             comment=serializer.validated_data["comment"],
             user=request.user,
+            is_public=is_public,
+            audience_groups=audience_groups,
         )
         return Response(
             self.get_serializer(log).data,

--- a/YSE_App/form_views.py
+++ b/YSE_App/form_views.py
@@ -5,7 +5,7 @@ from django.views import generic
 from django.contrib.auth import authenticate, login, logout
 from django.contrib.auth.decorators import login_required
 from django.conf import settings
-from django.urls import reverse_lazy
+from django.urls import reverse, reverse_lazy
 import requests
 import sys
 from datetime import datetime
@@ -41,7 +41,6 @@ def is_ajax(request):
 class AddTransientFollowupFormView(FormView):
 	form_class = TransientFollowupForm
 	template_name = 'YSE_App/form_snippets/transient_followup_form.html'
-	success_url = '/form-success/'
 
 	def get_form_kwargs(self):
 		kwargs = super().get_form_kwargs()
@@ -50,89 +49,112 @@ class AddTransientFollowupFormView(FormView):
 		if transient_id:
 			kwargs["transient_id"] = int(transient_id)
 		return kwargs
-	
+
+	def _transient_detail_success_url(self, transient):
+		return reverse("transient_detail", kwargs={"slug": transient.slug}) + "#followup_tab"
+
+	def _followup_response_data(self, instance, form):
+		data_dict = {
+			"id": instance.id,
+			"status_id": instance.status.id,
+			"status_name": instance.status.name,
+			"valid_start": instance.valid_start,
+			"valid_stop": instance.valid_stop,
+			"spec_priority": form.cleaned_data["spec_priority"],
+			"phot_priority": form.cleaned_data["phot_priority"],
+			"offset_star_ra": form.cleaned_data["offset_star_ra"],
+			"offset_star_dec": form.cleaned_data["offset_star_dec"],
+			"offset_north": form.cleaned_data["offset_north"],
+			"offset_east": form.cleaned_data["offset_east"],
+			"comment": form.cleaned_data["comment"],
+			"modified_by": instance.modified_by.username,
+		}
+		if instance.too_resource:
+			data_dict["too_resource"] = str(instance.too_resource)
+		if instance.classical_resource:
+			data_dict["classical_resource"] = str(instance.classical_resource)
+		if instance.queued_resource:
+			data_dict["queued_resource"] = str(instance.queued_resource)
+		return data_dict
+
+	def _create_followup_from_form(self, form):
+		from YSE_App.services.audience import resolve_followup_audience
+
+		instance = form.save(commit=False)
+		instance.created_by = self.request.user
+		instance.modified_by = self.request.user
+		instance.requested_by = self.request.user
+		instance.valid_start = form.cleaned_data["valid_start"]
+		instance.valid_stop = form.cleaned_data["valid_stop"]
+
+		is_public, audience_groups = resolve_followup_audience(
+			self.request.user,
+			instance.transient_id,
+			audience_groups=list(form.cleaned_data.get("audience_groups") or []),
+			linked_resource=(
+				form.cleaned_data.get("classical_resource")
+				or form.cleaned_data.get("too_resource")
+				or form.cleaned_data.get("queued_resource")
+			),
+			explicit_audience=True,
+		)
+		instance.is_public = is_public
+		instance.save()
+
+		if audience_groups:
+			instance.groups.set(audience_groups)
+
+		if instance.transient.status.name in ["New", "Watch", "Ignore", "Interesting"]:
+			instance.transient.status = TransientStatus.objects.filter(
+				name="FollowupRequested"
+			)[0]
+			instance.transient.save()
+
+		if form.cleaned_data["comment"]:
+			log = Log(
+				transient_followup=instance,
+				comment=form.cleaned_data["comment"],
+				created_by=self.request.user,
+				modified_by=self.request.user,
+			)
+			log.save()
+
+		return instance
+
 	def form_invalid(self, form):
-		response = super(AddTransientFollowupFormView, self).form_invalid(form)
 		if is_ajax(self.request):
 			return JsonResponse(form.errors, status=400)
-		else:
-			return response
+		transient_id = self.request.POST.get("transient")
+		if transient_id:
+			transient = Transient.objects.filter(pk=transient_id).only("slug").first()
+			if transient:
+				from django.contrib import messages
+
+				messages.error(
+					self.request,
+					"Could not save follow-up: "
+					+ "; ".join(
+						f"{field}: {', '.join(errors)}"
+						for field, errors in form.errors.items()
+					),
+				)
+				return HttpResponseRedirect(self._transient_detail_success_url(transient))
+		referer = self.request.META.get("HTTP_REFERER")
+		if referer:
+			return HttpResponseRedirect(referer)
+		return HttpResponseRedirect(reverse_lazy("dashboard"))
 
 	def form_valid(self, form):
-		response = super(AddTransientFollowupFormView, self).form_valid(form)
+		instance = self._create_followup_from_form(form)
 		if is_ajax(self.request):
-
-			instance = form.save(commit=False)
-			instance.created_by = self.request.user
-			instance.modified_by = self.request.user
-			instance.requested_by = self.request.user
-			if instance.classical_resource:
-				instance.valid_start = instance.classical_resource.begin_date_valid
-				instance.valid_stop = instance.classical_resource.end_date_valid
-
-			from YSE_App.services.audience import resolve_followup_audience
-
-			is_public, audience_groups = resolve_followup_audience(
-				self.request.user,
-				instance.transient_id,
-				is_public=form.cleaned_data.get("is_public", True),
-				audience_groups=form.cleaned_data.get("audience_groups"),
-			)
-			instance.is_public = is_public
-			instance.save() #update_fields=['created_by','modified_by']
-
-			if audience_groups:
-				instance.groups.set(audience_groups)
-
-			if instance.transient.status.name in ['New','Watch','Ignore','Interesting']:
-				instance.transient.status = TransientStatus.objects.filter(name='FollowupRequested')[0]
-				instance.transient.save()
-			
-			if form.cleaned_data['comment']:
-				log = Log(transient_followup=TransientFollowup.objects.get(id=instance.id),
-						  comment=form.cleaned_data['comment'])
-				log.created_by = self.request.user
-				log.modified_by = self.request.user
-				log.save()
-			
-			print(form.cleaned_data)
-
-			# for key,value in form.cleaned_data.items():
-			data_dict = {}
-			data_dict['id'] = instance.id
-			data_dict['status_id'] = instance.status.id
-			data_dict['status_name'] = instance.status.name
-			if instance.too_resource:
-				data_dict['too_resource'] = str(instance.too_resource)
-			if instance.classical_resource:
-				data_dict['classical_resource'] = str(instance.classical_resource)
-			if instance.queued_resource:
-				data_dict['queued_resource'] = str(instance.queued_resource)
-
-			if instance.classical_resource:
-				data_dict['valid_start'] = instance.classical_resource.begin_date_valid
-				data_dict['valid_stop'] = instance.classical_resource.end_date_valid
-			else:
-				data_dict['valid_start'] = form.cleaned_data['valid_start']
-				data_dict['valid_stop'] = form.cleaned_data['valid_stop']
-
-			data_dict['spec_priority'] = form.cleaned_data['spec_priority']
-			data_dict['phot_priority'] = form.cleaned_data['phot_priority']
-			data_dict['offset_star_ra'] = form.cleaned_data['offset_star_ra']
-			data_dict['offset_star_dec'] = form.cleaned_data['offset_star_dec']
-			data_dict['offset_north'] = form.cleaned_data['offset_north']
-			data_dict['offset_east'] = form.cleaned_data['offset_east']
-			data_dict['comment'] = form.cleaned_data['comment']
-			
-			data_dict['modified_by'] = instance.modified_by.username
-
 			data = {
-				'data':data_dict,
-				'message': "Successfully submitted form data.",
+				"data": self._followup_response_data(instance, form),
+				"message": "Successfully submitted form data.",
 			}
 			return JsonResponse(data)
-		else:
-			return response
+		return HttpResponseRedirect(
+			self._transient_detail_success_url(instance.transient)
+		)
 
 class AddClassicalResourceFormView(FormView):
 	form_class = ClassicalResourceForm
@@ -561,7 +583,6 @@ class AddOncallUserFormView(FormView):
 class AddTransientCommentFormView(FormView):
 	form_class = TransientCommentForm
 	template_name = 'simple.html'#YSE_App/form_snippets/transient_followup_form.html'
-	success_url = '/form-success/'
 
 	def get_form_kwargs(self):
 		kwargs = super().get_form_kwargs()
@@ -571,40 +592,43 @@ class AddTransientCommentFormView(FormView):
 			kwargs["transient_id"] = int(transient_id)
 		return kwargs
 
+	def _transient_detail_success_url(self, transient):
+		return reverse("transient_detail", kwargs={"slug": transient.slug})
+
+	def _create_comment_from_form(self, form):
+		from YSE_App.services.audience import resolve_comment_audience
+		from YSE_App.services.comments import create_transient_comment, log_to_comment_dict
+
+		transient = form.cleaned_data["transient"]
+		is_public, audience_groups = resolve_comment_audience(
+			self.request.user,
+			transient.id,
+			is_public=form.cleaned_data.get("is_public", False),
+			audience_groups=form.cleaned_data.get("audience_groups"),
+		)
+		log = create_transient_comment(
+			transient=transient,
+			comment=form.cleaned_data["comment"],
+			user=self.request.user,
+			is_public=is_public,
+			audience_groups=audience_groups,
+		)
+		return log, log_to_comment_dict(log)
+
 	def form_invalid(self, form):
-		response = super(AddTransientCommentFormView, self).form_invalid(form)
 		if is_ajax(self.request):
 			return JsonResponse(form.errors, status=400)
-		else:
-			return response
+		return super(AddTransientCommentFormView, self).form_invalid(form)
 
 	def form_valid(self, form):
-		response = super(AddTransientCommentFormView, self).form_valid(form)
+		log, comment_dict = self._create_comment_from_form(form)
 		if is_ajax(self.request):
-			from YSE_App.services.audience import resolve_comment_audience
-			from YSE_App.services.comments import create_transient_comment, log_to_comment_dict
-
-			transient = form.cleaned_data["transient"]
-			is_public, audience_groups = resolve_comment_audience(
-				self.request.user,
-				transient.id,
-				is_public=form.cleaned_data.get("is_public", False),
-				audience_groups=form.cleaned_data.get("audience_groups"),
-			)
-			log = create_transient_comment(
-				transient=transient,
-				comment=form.cleaned_data["comment"],
-				user=self.request.user,
-				is_public=is_public,
-				audience_groups=audience_groups,
-			)
 			data = {
 				"message": "Successfully submitted form data.",
-				"data": log_to_comment_dict(log),
+				"data": comment_dict,
 			}
 			return JsonResponse(data)
-		else:
-			return response
+		return HttpResponseRedirect(self._transient_detail_success_url(log.transient))
 		
 class AddDashboardQueryFormView(FormView):
 	form_class = AddDashboardQueryForm

--- a/YSE_App/form_views.py
+++ b/YSE_App/form_views.py
@@ -42,6 +42,14 @@ class AddTransientFollowupFormView(FormView):
 	form_class = TransientFollowupForm
 	template_name = 'YSE_App/form_snippets/transient_followup_form.html'
 	success_url = '/form-success/'
+
+	def get_form_kwargs(self):
+		kwargs = super().get_form_kwargs()
+		kwargs["user"] = self.request.user
+		transient_id = self.request.POST.get("transient") or self.request.GET.get("transient")
+		if transient_id:
+			kwargs["transient_id"] = int(transient_id)
+		return kwargs
 	
 	def form_invalid(self, form):
 		response = super(AddTransientFollowupFormView, self).form_invalid(form)
@@ -61,8 +69,20 @@ class AddTransientFollowupFormView(FormView):
 			if instance.classical_resource:
 				instance.valid_start = instance.classical_resource.begin_date_valid
 				instance.valid_stop = instance.classical_resource.end_date_valid
-			
+
+			from YSE_App.services.audience import resolve_followup_audience
+
+			is_public, audience_groups = resolve_followup_audience(
+				self.request.user,
+				instance.transient_id,
+				is_public=form.cleaned_data.get("is_public", True),
+				audience_groups=form.cleaned_data.get("audience_groups"),
+			)
+			instance.is_public = is_public
 			instance.save() #update_fields=['created_by','modified_by']
+
+			if audience_groups:
+				instance.groups.set(audience_groups)
 
 			if instance.transient.status.name in ['New','Watch','Ignore','Interesting']:
 				instance.transient.status = TransientStatus.objects.filter(name='FollowupRequested')[0]
@@ -543,6 +563,14 @@ class AddTransientCommentFormView(FormView):
 	template_name = 'simple.html'#YSE_App/form_snippets/transient_followup_form.html'
 	success_url = '/form-success/'
 
+	def get_form_kwargs(self):
+		kwargs = super().get_form_kwargs()
+		kwargs["user"] = self.request.user
+		transient_id = self.request.POST.get("transient") or self.request.GET.get("transient")
+		if transient_id:
+			kwargs["transient_id"] = int(transient_id)
+		return kwargs
+
 	def form_invalid(self, form):
 		response = super(AddTransientCommentFormView, self).form_invalid(form)
 		if is_ajax(self.request):
@@ -553,13 +581,22 @@ class AddTransientCommentFormView(FormView):
 	def form_valid(self, form):
 		response = super(AddTransientCommentFormView, self).form_valid(form)
 		if is_ajax(self.request):
+			from YSE_App.services.audience import resolve_comment_audience
 			from YSE_App.services.comments import create_transient_comment, log_to_comment_dict
 
 			transient = form.cleaned_data["transient"]
+			is_public, audience_groups = resolve_comment_audience(
+				self.request.user,
+				transient.id,
+				is_public=form.cleaned_data.get("is_public", False),
+				audience_groups=form.cleaned_data.get("audience_groups"),
+			)
 			log = create_transient_comment(
 				transient=transient,
 				comment=form.cleaned_data["comment"],
 				user=self.request.user,
+				is_public=is_public,
+				audience_groups=audience_groups,
 			)
 			data = {
 				"message": "Successfully submitted form data.",

--- a/YSE_App/forms.py
+++ b/YSE_App/forms.py
@@ -34,11 +34,6 @@ class TransientForm(ModelForm):
             'postage_stamp_file']
 
 class TransientFollowupForm(ModelForm):
-    is_public = forms.BooleanField(
-        required=False,
-        initial=True,
-        label="Visible to all YSE users who can open this transient",
-    )
     audience_groups = forms.ModelMultipleChoiceField(
         queryset=Group.objects.none(),
         required=False,
@@ -67,13 +62,135 @@ class TransientFollowupForm(ModelForm):
 
     def __init__(self, *args, user=None, transient_id=None, **kwargs):
         super().__init__(*args, **kwargs)
+        self._user = user
+        self.fields["valid_start"].required = False
+        self.fields["valid_stop"].required = False
+        if transient_id is not None:
+            self.fields["transient"].initial = transient_id
+            self.fields["transient"].widget = forms.HiddenInput()
         self.show_audience_picker = False
-        if user is not None and transient_id is not None:
-            from YSE_App.services.audience import selectable_audience_groups
+        self.followup_audience_choices = []
+        self.resource_audience_map = {}
 
-            qs = selectable_audience_groups(user, transient_id)
-            self.fields["audience_groups"].queryset = qs
-            self.show_audience_picker = qs.exists()
+        if user is not None:
+            from YSE_App import view_utils
+
+            valid_after = timezone.now() - timedelta(days=1)
+            self.fields["classical_resource"].queryset = (
+                view_utils.get_authorized_classical_resources(user)
+                .filter(end_date_valid__gt=valid_after)
+                .order_by("telescope__name")
+            )
+            self.fields["too_resource"].queryset = (
+                view_utils.get_authorized_too_resources(user)
+                .filter(end_date_valid__gt=valid_after)
+                .order_by("telescope__name")
+            )
+            self.fields["queued_resource"].queryset = (
+                view_utils.get_authorized_queued_resources(user)
+                .filter(end_date_valid__gt=valid_after)
+                .order_by("telescope__name")
+            )
+            classical_qs = self.fields["classical_resource"].queryset
+            if classical_qs.exists():
+                initial_resource = classical_qs.first()
+                self.fields["classical_resource"].initial = initial_resource
+                self.fields["valid_start"].initial = initial_resource.begin_date_valid
+                self.fields["valid_stop"].initial = initial_resource.end_date_valid
+
+            self.fields["audience_groups"].queryset = user.groups.order_by("name")
+            self.show_audience_picker = user.groups.exists()
+            from YSE_App.services.audience import (
+                build_followup_audience_choices,
+                build_followup_resource_audience_map,
+            )
+
+            linked_resource = self._linked_resource_from_bound_data()
+            self.followup_audience_choices = build_followup_audience_choices(
+                user, linked_resource
+            )
+            eligible_ids = [
+                choice["group"].pk
+                for choice in self.followup_audience_choices
+                if choice["enabled"]
+            ]
+            self.fields["audience_groups"].initial = eligible_ids
+            self.resource_audience_map = build_followup_resource_audience_map(self)
+            self.public_group_id = next(
+                (
+                    choice["group"].pk
+                    for choice in self.followup_audience_choices
+                    if choice["is_public_group"]
+                ),
+                None,
+            )
+
+    def _linked_resource_from_bound_data(self):
+        data = self.data if self.is_bound else None
+        for field_name in ("classical_resource", "too_resource", "queued_resource"):
+            if data is not None:
+                raw_pk = data.get(field_name)
+                if raw_pk:
+                    return self.fields[field_name].queryset.filter(pk=raw_pk).first()
+            initial = self.fields[field_name].initial
+            if initial is not None:
+                if hasattr(initial, "pk"):
+                    return initial
+                return self.fields[field_name].queryset.filter(pk=initial).first()
+        return None
+
+    def clean(self):
+        cleaned_data = super().clean()
+        classical = cleaned_data.get("classical_resource")
+        too = cleaned_data.get("too_resource")
+        queued = cleaned_data.get("queued_resource")
+        linked_resource = classical or too or queued
+        if classical:
+            cleaned_data["valid_start"] = classical.begin_date_valid
+            cleaned_data["valid_stop"] = classical.end_date_valid
+        elif not cleaned_data.get("valid_start") or not cleaned_data.get("valid_stop"):
+            if too or queued:
+                raise forms.ValidationError(
+                    "Provide a date range for ToO or queued follow-up requests."
+                )
+            raise forms.ValidationError(
+                "Select a classical, ToO, or queued resource for this follow-up."
+            )
+
+        if self._user is not None:
+            from rest_framework.exceptions import ValidationError as DRFValidationError
+            from YSE_App.services.audience import (
+                resolve_followup_audience,
+                resource_is_creator_only,
+            )
+
+            if not linked_resource:
+                raise forms.ValidationError(
+                    "Select a classical, ToO, or queued resource for this follow-up."
+                )
+
+            selected = cleaned_data.get("audience_groups")
+            selected_list = list(selected) if selected is not None else []
+            if not selected_list and not resource_is_creator_only(linked_resource):
+                raise forms.ValidationError(
+                    {
+                        "audience_groups": "Select at least one collaboration group.",
+                    }
+                )
+
+            try:
+                resolve_followup_audience(
+                    self._user,
+                    cleaned_data.get("transient").pk
+                    if cleaned_data.get("transient") is not None
+                    else 0,
+                    audience_groups=selected_list,
+                    linked_resource=linked_resource,
+                    explicit_audience=True,
+                )
+            except DRFValidationError as exc:
+                raise forms.ValidationError(exc.detail) from exc
+        return cleaned_data
 
     class Meta:
         model = TransientFollowup
@@ -210,7 +327,7 @@ class TransientCommentForm(ModelForm):
             qs = selectable_audience_groups(user, transient_id)
             self.fields["audience_groups"].queryset = qs
             self.fields["audience_groups"].initial = list(qs.values_list("pk", flat=True))
-            self.show_audience_picker = qs.count() > 1
+            self.show_audience_picker = qs.exists()
 
     class Meta:
         model = Log

--- a/YSE_App/forms.py
+++ b/YSE_App/forms.py
@@ -34,6 +34,18 @@ class TransientForm(ModelForm):
             'postage_stamp_file']
 
 class TransientFollowupForm(ModelForm):
+    is_public = forms.BooleanField(
+        required=False,
+        initial=True,
+        label="Visible to all YSE users who can open this transient",
+    )
+    audience_groups = forms.ModelMultipleChoiceField(
+        queryset=Group.objects.none(),
+        required=False,
+        label="Collaboration groups",
+        widget=forms.CheckboxSelectMultiple,
+    )
+
     status = forms.ModelChoiceField(
         FollowupStatus.objects.all(),
         initial=FollowupStatus.objects.filter(name='Requested').first())
@@ -52,6 +64,16 @@ class TransientFollowupForm(ModelForm):
         valid_start = forms.DateTimeField()
         valid_stop = forms.DateTimeField()
     comment = forms.CharField(required=False)
+
+    def __init__(self, *args, user=None, transient_id=None, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.show_audience_picker = False
+        if user is not None and transient_id is not None:
+            from YSE_App.services.audience import selectable_audience_groups
+
+            qs = selectable_audience_groups(user, transient_id)
+            self.fields["audience_groups"].queryset = qs
+            self.show_audience_picker = qs.exists()
 
     class Meta:
         model = TransientFollowup
@@ -167,6 +189,29 @@ class OncallForm(ModelForm):
 
 
 class TransientCommentForm(ModelForm):
+    is_public = forms.BooleanField(
+        required=False,
+        initial=False,
+        label="Visible to all YSE users who can open this transient",
+    )
+    audience_groups = forms.ModelMultipleChoiceField(
+        queryset=Group.objects.none(),
+        required=False,
+        label="Collaboration groups",
+        widget=forms.CheckboxSelectMultiple,
+    )
+
+    def __init__(self, *args, user=None, transient_id=None, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.show_audience_picker = False
+        if user is not None and transient_id is not None:
+            from YSE_App.services.audience import selectable_audience_groups
+
+            qs = selectable_audience_groups(user, transient_id)
+            self.fields["audience_groups"].queryset = qs
+            self.fields["audience_groups"].initial = list(qs.values_list("pk", flat=True))
+            self.show_audience_picker = qs.count() > 1
+
     class Meta:
         model = Log
         fields = [

--- a/YSE_App/management/commands/seed_security_test_matrix.py
+++ b/YSE_App/management/commands/seed_security_test_matrix.py
@@ -1,4 +1,4 @@
-"""Seed four security-test users and secvis-matrix transient (mag-labeled photometry)."""
+"""Seed four security-test users and secvis-matrix transient (mag-labeled photometry + resources)."""
 
 from __future__ import annotations
 
@@ -16,7 +16,8 @@ from YSE_App.tests.fixtures_security_matrix import (
 class Command(BaseCommand):
     help = (
         "Create security demo users (sec_user_ab, sec_user_ac, sec_user_b, sec_user_d) "
-        f"and transient {TRANSIENT_NAME} with mag-labeled photometry (0=public … 7=overlap)."
+        f"and transient {TRANSIENT_NAME} with mag-labeled photometry and observing "
+        "resources (0=public … 7=overlap)."
     )
 
     def add_arguments(self, parser):
@@ -42,5 +43,10 @@ class Command(BaseCommand):
             self.stdout.write(
                 f"  {username:14} groups={groups:8} expected LC mags: {expected}"
             )
+        self.stdout.write("")
+        self.stdout.write(
+            "Observing resources: SecVis-{Cls|Too|Que}-mag{N}-{suffix} "
+            "(same group rules as LC mags 0–7). Open Follow-up tab on transient detail."
+        )
         self.stdout.write("")
         self.stdout.write("Log in at /login/ and open the transient URL above.")

--- a/YSE_App/serializers/transient_comment_serializers.py
+++ b/YSE_App/serializers/transient_comment_serializers.py
@@ -6,6 +6,12 @@ from YSE_App.models import Log
 class TransientCommentSerializer(serializers.ModelSerializer):
     created_by = serializers.StringRelatedField(read_only=True)
     modified_by = serializers.StringRelatedField(read_only=True)
+    is_public = serializers.BooleanField(required=False, default=False)
+    audience_group_ids = serializers.ListField(
+        child=serializers.IntegerField(),
+        required=False,
+        write_only=True,
+    )
 
     class Meta:
         model = Log
@@ -13,6 +19,8 @@ class TransientCommentSerializer(serializers.ModelSerializer):
             "id",
             "comment",
             "transient",
+            "is_public",
+            "audience_group_ids",
             "created_by",
             "modified_by",
             "created_date",

--- a/YSE_App/services/audience.py
+++ b/YSE_App/services/audience.py
@@ -2,13 +2,15 @@
 
 from __future__ import annotations
 
-from typing import Iterable, List, Optional, Tuple
+from typing import Any, Dict, Iterable, List, Optional, Set, Tuple
 
 from django.contrib.auth.models import Group, User
 from rest_framework.exceptions import PermissionDenied, ValidationError
 
+from YSE_App.common.collaboration_groups import PUBLIC_COLLABORATION_GROUP_NAME
 from YSE_App.services.visibility import (
     default_comment_audience_groups,
+    object_has_groups,
     shared_groups_for_transient,
 )
 
@@ -25,8 +27,11 @@ def _groups_from_ids(
 ) -> List[Group]:
     if audience_group_ids is None:
         return []
+    ids = list(audience_group_ids)
+    if not ids:
+        return []
     allowed = selectable_audience_groups(user, transient_id)
-    selected = list(allowed.filter(id__in=audience_group_ids))
+    selected = list(allowed.filter(id__in=ids))
     if not selected:
         raise ValidationError(
             {"audience_groups": "Select at least one valid collaboration group."}
@@ -50,11 +55,14 @@ def resolve_comment_audience(
     """
     Return ``(is_public, audience_groups)`` for a new transient comment.
 
-    Default (unchecked ``is_public``, no explicit groups): private audience =
-    groups the user shares with restricted data on this transient.
+    - ``is_public=True``: all collaborators who can open the transient.
+    - Explicit empty group selection: creator-only (``is_public=False``, no groups).
+    - No explicit audience in the request: private to shared collaboration groups.
     """
     if is_public:
         return True, []
+
+    explicit_audience = audience_groups is not None or audience_group_ids is not None
 
     if audience_groups is not None:
         selected = list(audience_groups)
@@ -67,6 +75,8 @@ def resolve_comment_audience(
         return False, selected
 
     if not selected:
+        if explicit_audience:
+            return False, []
         fallback = default_comment_audience_groups(user, transient_id)
         if not fallback:
             return True, []
@@ -74,30 +84,163 @@ def resolve_comment_audience(
     return False, selected
 
 
+def linked_telescope_resource(classical=None, too=None, queued=None):
+    """Return the single linked observing resource, if any."""
+    return classical or too or queued
+
+
+def resource_is_public(resource) -> bool:
+    """Ungrouped telescope resources are visible to all authorized users."""
+    if resource is None:
+        return True
+    return not object_has_groups(resource)
+
+
+def resource_audience_group_ids(resource) -> Set[int]:
+    if resource is None:
+        return set()
+    return set(resource.groups.values_list("id", flat=True))
+
+
+def resource_is_creator_only(resource) -> bool:
+    """
+    True when the observing resource is private to the requester only.
+
+    No production resources use this yet; set ``creator_only`` on a resource row
+    when that workflow is introduced.
+    """
+    if resource is None:
+        return False
+    return bool(getattr(resource, "creator_only", False))
+
+
+def eligible_followup_audience_groups(user: User, resource) -> List[Group]:
+    """Collaboration groups the user may assign for a restricted follow-up."""
+    user_groups = list(user.groups.order_by("name"))
+    if resource_is_public(resource):
+        return user_groups
+    resource_ids = resource_audience_group_ids(resource)
+    return [
+        group
+        for group in user_groups
+        if group.name != PUBLIC_COLLABORATION_GROUP_NAME and group.id in resource_ids
+    ]
+
+
+def build_followup_audience_choices(user: User, resource) -> List[Dict[str, Any]]:
+    """All user groups with enabled/checked flags for the follow-up picker."""
+    eligible_ids = {group.id for group in eligible_followup_audience_groups(user, resource)}
+    resource_public = resource_is_public(resource)
+    choices: List[Dict[str, Any]] = []
+    for group in user.groups.order_by("name"):
+        is_public_group = group.name == PUBLIC_COLLABORATION_GROUP_NAME
+        if is_public_group:
+            enabled = resource_public
+        else:
+            enabled = group.id in eligible_ids
+        choices.append(
+            {
+                "group": group,
+                "enabled": enabled,
+                "checked": enabled,
+                "is_public_group": is_public_group,
+            }
+        )
+    return choices
+
+
+def build_followup_resource_audience_map(form) -> Dict[str, Dict[str, Any]]:
+    """Map ``field_name:pk`` to resource audience metadata for client-side sync."""
+    resource_map: Dict[str, Dict[str, Any]] = {}
+    for field_name in ("classical_resource", "too_resource", "queued_resource"):
+        for resource in form.fields[field_name].queryset.prefetch_related("groups"):
+            resource_map[f"{field_name}:{resource.pk}"] = {
+                "is_public": resource_is_public(resource),
+                "group_ids": list(resource.groups.values_list("pk", flat=True)),
+            }
+    return resource_map
+
+
+def _followup_groups_from_ids(
+    user: User,
+    linked_resource,
+    audience_group_ids: Iterable[int],
+) -> List[Group]:
+    ids = list(audience_group_ids)
+    if not ids:
+        return []
+    eligible_ids = {group.id for group in eligible_followup_audience_groups(user, linked_resource)}
+    selected = list(user.groups.filter(id__in=ids))
+    if not selected:
+        raise ValidationError(
+            {"audience_groups": "Select at least one valid collaboration group."}
+        )
+    invalid = [group for group in selected if group.id not in eligible_ids]
+    if invalid:
+        raise ValidationError(
+            {
+                "audience_groups": (
+                    "One or more selected groups cannot see the linked observing resource."
+                )
+            }
+        )
+    return selected
+
+
 def resolve_followup_audience(
     user: User,
     transient_id: int,
     *,
-    is_public: bool,
     audience_group_ids: Optional[Iterable[int]] = None,
     audience_groups: Optional[Iterable[Group]] = None,
+    linked_resource=None,
+    explicit_audience: bool = True,
 ) -> Tuple[bool, List[Group]]:
-    """Return ``(is_public, audience_groups)`` for a new follow-up request."""
-    if is_public:
-        return True, []
+    """
+    Return ``(is_public, audience_groups)`` for a new follow-up request.
+
+    New follow-ups are always stored with ``is_public=False``; audience is set
+    via collaboration groups. Select the ``Public`` group to share with all
+    members of that group (only when the linked resource is itself public).
+
+    Creator-only (no groups) is allowed only for creator-only observing resources.
+    """
+    eligible = eligible_followup_audience_groups(user, linked_resource)
+    eligible_ids = {group.id for group in eligible}
 
     if audience_groups is not None:
         selected = list(audience_groups)
     elif audience_group_ids is not None:
-        selected = _groups_from_ids(user, transient_id, audience_group_ids)
+        selected = _followup_groups_from_ids(user, linked_resource, audience_group_ids)
+    elif explicit_audience:
+        selected = []
     else:
-        selected = list(selectable_audience_groups(user, transient_id))
-        if not selected:
-            return True, []
-        return False, selected
+        selected = eligible
 
     if not selected:
+        if resource_is_creator_only(linked_resource):
+            return False, []
         raise ValidationError(
-            {"audience_groups": "Select collaboration groups for a restricted follow-up."}
+            {"audience_groups": "Select at least one collaboration group."}
+        )
+
+    invalid = [group for group in selected if group.id not in eligible_ids]
+    if invalid:
+        raise ValidationError(
+            {
+                "audience_groups": (
+                    "One or more selected groups cannot see the linked observing resource."
+                )
+            }
+        )
+    if any(
+        group.name == PUBLIC_COLLABORATION_GROUP_NAME for group in selected
+    ) and not resource_is_public(linked_resource):
+        raise ValidationError(
+            {
+                "audience_groups": (
+                    "The Public group can only be selected for public observing resources."
+                )
+            }
         )
     return False, selected

--- a/YSE_App/services/audience.py
+++ b/YSE_App/services/audience.py
@@ -1,0 +1,103 @@
+"""Create-time audience resolution for comments and follow-ups (v1)."""
+
+from __future__ import annotations
+
+from typing import Iterable, List, Optional, Tuple
+
+from django.contrib.auth.models import Group, User
+from rest_framework.exceptions import PermissionDenied, ValidationError
+
+from YSE_App.services.visibility import (
+    default_comment_audience_groups,
+    shared_groups_for_transient,
+)
+
+
+def selectable_audience_groups(user: User, transient_id: int):
+    """Collaboration groups the user may assign at create time."""
+    return shared_groups_for_transient(user, transient_id).order_by("name")
+
+
+def _groups_from_ids(
+    user: User,
+    transient_id: int,
+    audience_group_ids: Optional[Iterable[int]],
+) -> List[Group]:
+    if audience_group_ids is None:
+        return []
+    allowed = selectable_audience_groups(user, transient_id)
+    selected = list(allowed.filter(id__in=audience_group_ids))
+    if not selected:
+        raise ValidationError(
+            {"audience_groups": "Select at least one valid collaboration group."}
+        )
+    user_ids = set(user.groups.values_list("id", flat=True))
+    if any(group.id not in user_ids for group in selected):
+        raise PermissionDenied(
+            {"message": "You cannot assign collaboration groups you do not belong to."}
+        )
+    return selected
+
+
+def resolve_comment_audience(
+    user: User,
+    transient_id: int,
+    *,
+    is_public: bool,
+    audience_group_ids: Optional[Iterable[int]] = None,
+    audience_groups: Optional[Iterable[Group]] = None,
+) -> Tuple[bool, List[Group]]:
+    """
+    Return ``(is_public, audience_groups)`` for a new transient comment.
+
+    Default (unchecked ``is_public``, no explicit groups): private audience =
+    groups the user shares with restricted data on this transient.
+    """
+    if is_public:
+        return True, []
+
+    if audience_groups is not None:
+        selected = list(audience_groups)
+    elif audience_group_ids is not None:
+        selected = _groups_from_ids(user, transient_id, audience_group_ids)
+    else:
+        selected = default_comment_audience_groups(user, transient_id)
+        if not selected:
+            return True, []
+        return False, selected
+
+    if not selected:
+        fallback = default_comment_audience_groups(user, transient_id)
+        if not fallback:
+            return True, []
+        return False, fallback
+    return False, selected
+
+
+def resolve_followup_audience(
+    user: User,
+    transient_id: int,
+    *,
+    is_public: bool,
+    audience_group_ids: Optional[Iterable[int]] = None,
+    audience_groups: Optional[Iterable[Group]] = None,
+) -> Tuple[bool, List[Group]]:
+    """Return ``(is_public, audience_groups)`` for a new follow-up request."""
+    if is_public:
+        return True, []
+
+    if audience_groups is not None:
+        selected = list(audience_groups)
+    elif audience_group_ids is not None:
+        selected = _groups_from_ids(user, transient_id, audience_group_ids)
+    else:
+        selected = list(selectable_audience_groups(user, transient_id))
+        if not selected:
+            return True, []
+        return False, selected
+
+    if not selected:
+        raise ValidationError(
+            {"audience_groups": "Select collaboration groups for a restricted follow-up."}
+        )
+    return False, selected

--- a/YSE_App/services/comments.py
+++ b/YSE_App/services/comments.py
@@ -71,6 +71,8 @@ def create_transient_comment(
         if not audience_groups:
             # No collaboration groups to scope to (e.g. public-only transient).
             is_public = True
+    elif audience_groups == [] and not is_public:
+        audience_groups = []
 
     log = Log.objects.create(
         transient=transient,

--- a/YSE_App/services/visibility.py
+++ b/YSE_App/services/visibility.py
@@ -6,7 +6,9 @@ from enum import Enum
 from typing import Iterable, List, Optional, Set, Union
 
 from django.contrib.auth.models import Group, User
-from django.db.models import Q, QuerySet
+from django.db.models import Count, Exists, OuterRef, Q, QuerySet
+
+from YSE_App.common.collaboration_groups import PUBLIC_COLLABORATION_GROUP_NAME
 
 
 class ResourceVisibilityPolicy(str, Enum):
@@ -123,8 +125,12 @@ def filter_transient_comments_for_user(queryset: QuerySet, user: User) -> QueryS
     if user.is_staff or user.is_superuser:
         return queryset
     names = user_group_names(user)
-    return queryset.filter(
-        Q(is_public=True) | Q(groups__name__in=names)
+    return queryset.annotate(
+        _audience_group_count=Count("groups", distinct=True),
+    ).filter(
+        Q(is_public=True)
+        | Q(groups__name__in=names)
+        | Q(created_by=user, is_public=False, _audience_group_count=0)
     ).distinct()
 
 
@@ -136,7 +142,7 @@ def log_visible_to_user(user: User, log) -> bool:
     if getattr(log, "is_public", True):
         return True
     if not object_has_groups(log):
-        return False
+        return log.created_by_id == user.id
     names = set(user_group_names(user))
     obj_names = set(log.groups.values_list("name", flat=True))
     return bool(names.intersection(obj_names))
@@ -161,14 +167,71 @@ def filter_transients_by_user_access(
     return [t for t in transients if user_can_view_transient(user, t.id)]
 
 
-def _followup_linked_resource_group_q(user: User) -> Q:
-    """Q for follow-up visible via linked telescope resource groups."""
+def _user_in_public_group(user: User) -> bool:
+    return PUBLIC_COLLABORATION_GROUP_NAME in user_group_names(user)
+
+
+def _linked_followup_resource(followup):
+    for attr in ("classical_resource", "too_resource", "queued_resource"):
+        resource = getattr(followup, attr, None)
+        if resource is not None:
+            return resource
+    return None
+
+
+def user_can_see_linked_followup_resource(user: User, followup) -> bool:
+    """Whether ``user`` may view the observing resource linked to a follow-up."""
+    resource = _linked_followup_resource(followup)
+    if resource is None:
+        return True
+    return object_visible_to_user(user, resource)
+
+
+def _observing_resource_ids_visible_to_user(model, user: User) -> Set[int]:
     names = user_group_names(user)
-    return (
-        Q(classical_resource__groups__name__in=names)
-        | Q(too_resource__groups__name__in=names)
-        | Q(queued_resource__groups__name__in=names)
+    public_ids = set(
+        model.objects.annotate(_resource_group_count=Count("groups"))
+        .filter(_resource_group_count=0)
+        .values_list("pk", flat=True)
     )
+    grouped_ids = set(
+        model.objects.filter(groups__name__in=names).values_list("pk", flat=True)
+    )
+    return public_ids | grouped_ids
+
+
+def _linked_resource_visible_q(user: User) -> Q:
+    """Q matching follow-ups whose linked observing resource is visible to ``user``."""
+    from YSE_App.models import ClassicalResource, QueuedResource, ToOResource
+
+    classical_ids = _observing_resource_ids_visible_to_user(ClassicalResource, user)
+    too_ids = _observing_resource_ids_visible_to_user(ToOResource, user)
+    queued_ids = _observing_resource_ids_visible_to_user(QueuedResource, user)
+    q = Q(
+        classical_resource__isnull=True,
+        too_resource__isnull=True,
+        queued_resource__isnull=True,
+    )
+    if classical_ids:
+        q |= Q(classical_resource__in=classical_ids)
+    if too_ids:
+        q |= Q(too_resource__in=too_ids)
+    if queued_ids:
+        q |= Q(queued_resource__in=queued_ids)
+    return q
+
+
+def _legacy_public_followup_ids(user: User) -> List[int]:
+    """PKs for legacy ``is_public=True`` follow-ups with no explicit groups."""
+    from YSE_App.models import TransientFollowup
+
+    qs = TransientFollowup.objects.annotate(_followup_group_count=Count("groups")).filter(
+        is_public=True,
+        _followup_group_count=0,
+    )
+    if not _user_in_public_group(user):
+        qs = qs.filter(requested_by=user)
+    return list(qs.values_list("pk", flat=True))
 
 
 def filter_transient_followups_for_user(queryset: QuerySet, user: User) -> QuerySet:
@@ -176,6 +239,7 @@ def filter_transient_followups_for_user(queryset: QuerySet, user: User) -> Query
     if user.is_staff or user.is_superuser:
         return queryset
     from YSE_App.data import PhotometryService, SpectraService
+    from YSE_App.models import TransientFollowup
 
     names = user_group_names(user)
     phot_transients = PhotometryService.GetAuthorizedTransientPhotometry_ByUser(
@@ -184,13 +248,24 @@ def filter_transient_followups_for_user(queryset: QuerySet, user: User) -> Query
     spec_transients = SpectraService.GetAuthorizedTransientSpectrum_ByUser(
         user
     ).values_list("transient_id", flat=True)
-    return queryset.filter(
+    scoped = queryset.filter(
         Q(transient_id__in=phot_transients) | Q(transient_id__in=spec_transients),
-        Q(is_public=True)
-        | Q(groups__name__in=names)
-        | Q(requested_by=user)
-        | _followup_linked_resource_group_q(user),
-    ).distinct()
+    ).filter(_linked_resource_visible_q(user))
+    followup_group_link = TransientFollowup.groups.through.objects.filter(
+        transientfollowup_id=OuterRef("pk"),
+    )
+    by_audience = scoped.filter(
+        Exists(followup_group_link),
+        groups__name__in=names,
+    )
+    creator_only = scoped.filter(
+        ~Exists(followup_group_link),
+        is_public=False,
+        requested_by=user,
+    )
+    legacy_ids = _legacy_public_followup_ids(user)
+    legacy = scoped.filter(pk__in=legacy_ids) if legacy_ids else scoped.none()
+    return (by_audience | creator_only | legacy).distinct()
 
 
 def followup_visible_to_user(user: User, followup) -> bool:
@@ -201,17 +276,16 @@ def followup_visible_to_user(user: User, followup) -> bool:
     transient_id = getattr(followup, "transient_id", None)
     if transient_id is not None and not user_can_view_transient(user, transient_id):
         return False
-    if getattr(followup, "is_public", True):
-        return True
-    if followup.requested_by_id == user.id:
-        return True
+    if not user_can_see_linked_followup_resource(user, followup):
+        return False
     if object_has_groups(followup):
         names = set(user_group_names(user))
         obj_names = set(followup.groups.values_list("name", flat=True))
-        if names.intersection(obj_names):
+        return bool(names.intersection(obj_names))
+    if getattr(followup, "is_public", False):
+        if followup.requested_by_id == user.id:
             return True
-    for attr in ("classical_resource", "too_resource", "queued_resource"):
-        res = getattr(followup, attr, None)
-        if res is not None and object_visible_to_user(user, res):
-            return True
+        return _user_in_public_group(user)
+    if followup.requested_by_id == user.id:
+        return True
     return False

--- a/YSE_App/templates/YSE_App/form_snippets/transient_followup_form.html
+++ b/YSE_App/templates/YSE_App/form_snippets/transient_followup_form.html
@@ -94,6 +94,25 @@
 					</div>
 				</div>-->
 				<div class="col-xs-12">
+					<div class="yse-audience-panel yse-followup-audience">
+						<p class="yse-audience-heading text-muted"><strong>Who can see this follow-up?</strong></p>
+						<div class="checkbox yse-audience-public">
+							<label>
+								{% render_field form.is_public class+="yse-audience-toggle-public" %}
+								{{ form.is_public.label }}
+							</label>
+						</div>
+						<div id="yse-followup-audience-groups" class="yse-audience-groups yse-followup-audience-groups">
+							{% if form.show_audience_picker %}
+								<p class="text-muted small">Restrict to collaboration groups:</p>
+								{% for checkbox in form.audience_groups %}
+								<div class="checkbox">{{ checkbox }}</div>
+								{% endfor %}
+							{% endif %}
+						</div>
+					</div>
+				</div>
+				<div class="col-xs-12">
 					<div class="form-group">
 						<br>
 						<button type="submit" class="btn btn-block btn-primary btn-lg">Submit</button>

--- a/YSE_App/templates/YSE_App/form_snippets/transient_followup_form.html
+++ b/YSE_App/templates/YSE_App/form_snippets/transient_followup_form.html
@@ -9,7 +9,8 @@
 			</div>
 		</div>
 		<div class="box-body">
-			<form id="add_transient_followup" action="{% url 'add_transient_followup' %}" method="post">
+			{{ form.resource_audience_map|json_script:"yse-followup-resource-audience-map" }}
+			<form id="add_transient_followup" action="{% url 'add_transient_followup' %}" method="post" onsubmit="return false;">
 				{% csrf_token %}
 				{% for hidden_field in form.hidden_fields %}
 					{{ hidden_field }}
@@ -53,8 +54,8 @@
 							</div>
 							<input type="text" class="form-control pull-right" id="follow_date_range">
 						</div>
-						<input type="hidden" id="{{form.valid_start.name}}" name="{{form.valid_start.name}}">
-						<input type="hidden" id="{{form.valid_stop.name}}" name="{{form.valid_stop.name}}">
+						<input type="hidden" id="{{ form.valid_start.id_for_label }}" name="{{ form.valid_start.name }}"{% if form.valid_start.value %} value="{{ form.valid_start.value|date:'Y-m-d H:i:s' }}"{% endif %}>
+						<input type="hidden" id="{{ form.valid_stop.id_for_label }}" name="{{ form.valid_stop.name }}"{% if form.valid_stop.value %} value="{{ form.valid_stop.value|date:'Y-m-d H:i:s' }}"{% endif %}>
 					</div>
 				</div>
 				<!--<div class="col-xs-6">
@@ -94,19 +95,29 @@
 					</div>
 				</div>-->
 				<div class="col-xs-12">
-					<div class="yse-audience-panel yse-followup-audience">
+					<div class="yse-audience-panel yse-followup-audience"{% if form.public_group_id %} data-public-group-id="{{ form.public_group_id }}"{% endif %}>
 						<p class="yse-audience-heading text-muted"><strong>Who can see this follow-up?</strong></p>
-						<div class="checkbox yse-audience-public">
-							<label>
-								{% render_field form.is_public class+="yse-audience-toggle-public" %}
-								{{ form.is_public.label }}
-							</label>
-						</div>
 						<div id="yse-followup-audience-groups" class="yse-audience-groups yse-followup-audience-groups">
 							{% if form.show_audience_picker %}
-								<p class="text-muted small">Restrict to collaboration groups:</p>
-								{% for checkbox in form.audience_groups %}
-								<div class="checkbox">{{ checkbox }}</div>
+								<p class="text-muted small">
+									Select collaboration groups that can see the selected observing resource
+									(default: all eligible groups checked). Check <strong>Public</strong> to share
+									with everyone in the Public group (only available for public observing resources).
+								</p>
+								{% for choice in form.followup_audience_choices %}
+								<div class="checkbox yse-followup-audience-choice" data-group-id="{{ choice.group.pk }}">
+									<label class="yse-followup-audience-label{% if not choice.enabled %} text-muted{% endif %}">
+										<input type="checkbox"
+											name="audience_groups"
+											value="{{ choice.group.pk }}"
+											class="yse-followup-audience-group"
+											{% if choice.checked %}checked{% endif %}
+											{% if not choice.enabled %}disabled{% endif %}
+											data-resource-eligible="{{ choice.enabled|yesno:'true,false' }}"
+											data-is-public-group="{{ choice.is_public_group|yesno:'true,false' }}">
+										{{ choice.group.name }}
+									</label>
+								</div>
 								{% endfor %}
 							{% endif %}
 						</div>
@@ -114,8 +125,9 @@
 				</div>
 				<div class="col-xs-12">
 					<div class="form-group">
+						<div class="yse-followup-submit-error alert alert-danger" role="alert" style="display:none; margin-top:10px;"></div>
 						<br>
-						<button type="submit" class="btn btn-block btn-primary btn-lg">Submit</button>
+						<button type="button" class="btn btn-block btn-primary btn-lg yse-followup-submit-btn">Submit</button>
 					</div>
 				</div>
 			</form>

--- a/YSE_App/templates/YSE_App/transient_detail.html
+++ b/YSE_App/templates/YSE_App/transient_detail.html
@@ -240,6 +240,279 @@
             setPlotHtml("#lcplot", html,
                 '<p class="text-muted yse-plot-empty">No photometry to plot.</p>');
         });
+
+    /* Follow-up audience panel — defined before deferred fragments (race with 2nd script block). */
+    (function() {
+        var resourceFields = ['classical_resource', 'too_resource', 'queued_resource'];
+
+        function yseParseFollowupResourceAudienceMap() {
+            var el = document.getElementById('yse-followup-resource-audience-map');
+            if (!el || !el.textContent) {
+                return {};
+            }
+            try {
+                return JSON.parse(el.textContent);
+            } catch (err) {
+                return {};
+            }
+        }
+
+        function yseUpdateActiveFollowupResourceField($form) {
+            var active = null;
+            resourceFields.forEach(function(name) {
+                var val = $form.find('select[name=' + name + ']').val();
+                if (val) {
+                    active = name;
+                }
+            });
+            $form.data('active-resource-field', active);
+            return active;
+        }
+
+        function yseSelectedFollowupResourceMeta($form, map) {
+            map = map || yseParseFollowupResourceAudienceMap();
+            var activeField = $form.data('active-resource-field');
+            if (!activeField) {
+                activeField = yseUpdateActiveFollowupResourceField($form);
+            }
+            if (!activeField) {
+                return { is_public: false, group_ids: [] };
+            }
+            var resourcePk = $form.find('select[name=' + activeField + ']').val();
+            if (!resourcePk) {
+                return { is_public: false, group_ids: [] };
+            }
+            var key = activeField + ':' + resourcePk;
+            return map[key] || { is_public: false, group_ids: [] };
+        }
+
+        function yseGroupIdEligible(groupId, meta) {
+            if (meta.public_group_id && groupId === meta.public_group_id) {
+                return !!meta.is_public;
+            }
+            if (meta.is_public) {
+                return true;
+            }
+            var ids = (meta.group_ids || []).map(function(id) { return parseInt(id, 10); });
+            return ids.indexOf(groupId) >= 0;
+        }
+
+        function yseSyncFollowupAudiencePanel($form, resetEligible) {
+            $form = $form && $form.length ? $form : $('#add_transient_followup');
+            if (!$form.length) {
+                return;
+            }
+            var $panel = $form.find('.yse-followup-audience');
+            if (!$panel.length) {
+                return;
+            }
+            var map = yseParseFollowupResourceAudienceMap();
+            var meta = yseSelectedFollowupResourceMeta($form, map);
+            var publicGroupId = parseInt($panel.data('public-group-id'), 10);
+            if (!isNaN(publicGroupId)) {
+                meta.public_group_id = publicGroupId;
+            }
+
+            $panel.find('.yse-followup-audience-group').each(function() {
+                var $cb = $(this);
+                var groupId = parseInt($cb.val(), 10);
+                var isPublicGroup = $cb.data('is-public-group') === true
+                    || $cb.data('is-public-group') === 'true';
+                var eligible = isPublicGroup ? !!meta.is_public : yseGroupIdEligible(groupId, meta);
+                var $label = $cb.closest('.yse-followup-audience-label');
+                var $choice = $cb.closest('.yse-followup-audience-choice');
+                if (!eligible) {
+                    $cb.prop('disabled', true).prop('checked', false);
+                    $label.addClass('text-muted');
+                    $choice.addClass('yse-followup-audience-ineligible');
+                } else {
+                    $cb.prop('disabled', false);
+                    if (resetEligible) {
+                        $cb.prop('checked', true);
+                    }
+                    $label.removeClass('text-muted');
+                    $choice.removeClass('yse-followup-audience-ineligible');
+                }
+            });
+        }
+
+        function yseInitFollowupResourceAudience($form) {
+            $form = $form && $form.length ? $form : $('#add_transient_followup');
+            if (!$form.length) {
+                return;
+            }
+            yseUpdateActiveFollowupResourceField($form);
+            yseSyncFollowupAudiencePanel($form, true);
+        }
+
+        function yseFollowupShowSubmitError(message) {
+            var $form = $('#add_transient_followup');
+            if (!$form.length) {
+                window.alert(message);
+                return;
+            }
+            var $err = $form.find('.yse-followup-submit-error').first();
+            if (!$err.length) {
+                $err = $('<div class="alert alert-danger yse-followup-submit-error" role="alert" style="margin-top:10px;"></div>');
+                $form.find('.yse-followup-submit-btn').closest('.form-group').prepend($err);
+            }
+            $err.text(message).show();
+        }
+
+        function yseFollowupClearSubmitError() {
+            $('#add_transient_followup .yse-followup-submit-error').hide();
+        }
+
+        function yseFollowupAudienceSelectionValid($form) {
+            $form = $form && $form.length ? $form : $('#add_transient_followup');
+            if (!$form.length) {
+                return false;
+            }
+            var hasResource = false;
+            resourceFields.forEach(function(name) {
+                if ($form.find('select[name=' + name + ']').val()) {
+                    hasResource = true;
+                }
+            });
+            if (!hasResource) {
+                yseFollowupShowSubmitError(
+                    'Select a classical, ToO, or queued resource for this follow-up.'
+                );
+                return false;
+            }
+            var checkedEligible = $form.find(
+                '.yse-followup-audience-group:checked:not(:disabled)'
+            ).length;
+            if ($form.find('.yse-followup-audience-group').length && checkedEligible < 1) {
+                yseFollowupShowSubmitError(
+                    'Select at least one collaboration group for this follow-up.'
+                );
+                return false;
+            }
+            yseFollowupClearSubmitError();
+            return true;
+        }
+        window.yseFollowupAudienceSelectionValid = yseFollowupAudienceSelectionValid;
+        window.yseFollowupShowSubmitError = yseFollowupShowSubmitError;
+        window.yseFollowupClearSubmitError = yseFollowupClearSubmitError;
+
+        function yseSubmitTransientFollowup() {
+            var $form = $('#add_transient_followup');
+            if (!$form.length) {
+                yseFollowupShowSubmitError('Follow-up form is not loaded yet.');
+                return;
+            }
+            if (!yseFollowupAudienceSelectionValid($form)) {
+                return;
+            }
+            yseFollowupClearSubmitError();
+            var submitUrl = $form.attr('action') || "{% url 'add_transient_followup' %}";
+            var data = $form.serialize();
+            var transient_id = $form.find('input[name="transient"]').val() || $('#transient_pk').val();
+            if (transient_id && data.indexOf('transient=') === -1) {
+                data = data + '&transient=' + encodeURIComponent(transient_id);
+            }
+            var $btn = $form.find('.yse-followup-submit-btn');
+            $btn.prop('disabled', true);
+            $.ajax({
+                url: submitUrl,
+                type: 'POST',
+                headers: { 'X-Requested-With': 'XMLHttpRequest' },
+                dataType: 'json',
+                data: data,
+                success: function(json) {
+                    $('a[href="#followup_tab"]').tab('show');
+                    if (typeof window.yseOnTransientFollowupCreated === 'function') {
+                        window.yseOnTransientFollowupCreated(json);
+                    } else if (window.yseResetFollowupFragmentCache && window.yseLoadFollowupPhased) {
+                        window.yseResetFollowupFragmentCache();
+                        window.yseLoadFollowupPhased();
+                    }
+                    $('#add_transient_followup_btn').first().trigger('click');
+                    $form[0].reset();
+                    if (window.yseInitFollowupResourceAudience) {
+                        window.yseInitFollowupResourceAudience($form);
+                    }
+                    if (window.yseInitFollowupTabWidgets) {
+                        window.yseInitFollowupTabWidgets();
+                    }
+                    yseFollowupClearSubmitError();
+                },
+                error: function(xhr) {
+                    var message = xhr.responseText || 'Could not save follow-up.';
+                    try {
+                        var errors = JSON.parse(xhr.responseText);
+                        message = Object.keys(errors).map(function(key) {
+                            var val = errors[key];
+                            return key + ': ' + (Array.isArray(val) ? val.join(', ') : val);
+                        }).join('\n');
+                    } catch (parseErr) {}
+                    yseFollowupShowSubmitError(message);
+                },
+                complete: function() {
+                    $btn.prop('disabled', false);
+                }
+            });
+        }
+        window.yseSubmitTransientFollowup = yseSubmitTransientFollowup;
+        window.add_transient_followup = yseSubmitTransientFollowup;
+
+        function yseTriggerFollowupSubmit() {
+            yseSubmitTransientFollowup();
+        }
+        window.yseTriggerFollowupSubmit = yseTriggerFollowupSubmit;
+
+        if (!window.yseFollowupSubmitDelegationBound) {
+            window.yseFollowupSubmitDelegationBound = true;
+            $(document).on('submit', '#add_transient_followup', function(event) {
+                event.preventDefault();
+                yseTriggerFollowupSubmit();
+                return false;
+            });
+            $(document).on('click', '#add_transient_followup .yse-followup-submit-btn', function(event) {
+                event.preventDefault();
+                yseTriggerFollowupSubmit();
+                return false;
+            });
+        }
+
+        window.yseSyncFollowupAudiencePanel = yseSyncFollowupAudiencePanel;
+        window.yseInitFollowupResourceAudience = yseInitFollowupResourceAudience;
+
+        if (!window.yseFollowupAudienceDelegationBound) {
+            window.yseFollowupAudienceDelegationBound = true;
+            function yseOnFollowupResourceSelected() {
+                var $form = $('#add_transient_followup');
+                if (!$form.length) {
+                    return;
+                }
+                var fieldName = $(this).attr('name');
+                var val = $(this).val();
+                if (val) {
+                    resourceFields.forEach(function(other) {
+                        if (other !== fieldName) {
+                            var $other = $form.find('select[name=' + other + ']');
+                            if ($other.val()) {
+                                $other.val('').trigger('change');
+                            }
+                        }
+                    });
+                    $form.data('active-resource-field', fieldName);
+                } else {
+                    yseUpdateActiveFollowupResourceField($form);
+                }
+                yseSyncFollowupAudiencePanel($form, true);
+            }
+            $(document).on(
+                'change select2:select',
+                '#add_transient_followup select[name=classical_resource], ' +
+                '#add_transient_followup select[name=too_resource], ' +
+                '#add_transient_followup select[name=queued_resource]',
+                yseOnFollowupResourceSelected
+            );
+        }
+    })();
+
 {% if transient_detail_defer %}
         function yseUpdateArchiveTabLabel($tab, url, emptyLabel) {
             if (!$tab.length) {
@@ -285,8 +558,13 @@
                 if (key === 'followup_requests' && $.fn.boxWidget) {
                     $('.followupbox').boxWidget();
                 }
-                if (key === 'followup_rest' && window.yseInitFollowupTabWidgets) {
-                    window.yseInitFollowupTabWidgets();
+                if (key === 'followup_rest') {
+                    if (window.yseInitFollowupTabWidgets) {
+                        window.yseInitFollowupTabWidgets();
+                    }
+                    if (window.yseInitFollowupResourceAudience) {
+                        window.yseInitFollowupResourceAudience();
+                    }
                 }
                 deferred.resolve();
             }).fail(function() {
@@ -321,10 +599,23 @@
             });
             return yseFollowupLoadPromise;
         }
+        window.yseLoadFollowupPhased = yseLoadFollowupPhased;
+        window.yseResetFollowupFragmentCache = function() {
+            yseFollowupLoadPromise = null;
+            delete yseDetailFragmentsLoaded['followup_requests'];
+            delete yseDetailFragmentsLoaded['followup_rest'];
+            delete yseDetailFragmentsLoaded['followup_classical'];
+        };
 
         var yseHstImagesLoaded = false;
         var yseChandraImagesLoaded = false;
         $(function() {
+            if (window.location.hash === '#followup_tab') {
+                if (window.yseResetFollowupFragmentCache) {
+                    window.yseResetFollowupFragmentCache();
+                }
+                $('a[href="#followup_tab"]').tab('show');
+            }
             $('a[data-toggle="tab"]').on('shown.bs.tab', function(e) {
                 var target = $(e.target).attr('href');
                 if (target === '#followup_tab') {
@@ -1064,6 +1355,12 @@
                 $root = $root || $(document);
                 $root.find('.yse-audience-panel').each(function() {
                     var $panel = $(this);
+                    if ($panel.hasClass('yse-followup-audience')) {
+                        if (window.yseSyncFollowupAudiencePanel) {
+                            window.yseSyncFollowupAudiencePanel($panel.closest('form'), false);
+                        }
+                        return;
+                    }
                     var $public = $panel.find('.yse-audience-toggle-public');
                     var $groups = $panel.find('.yse-audience-groups');
                     if (!$public.length) {
@@ -1081,6 +1378,9 @@
 
             $(function() {
                 yseSyncAudiencePanels();
+                if (window.yseInitFollowupResourceAudience) {
+                    window.yseInitFollowupResourceAudience($('#add_transient_followup'));
+                }
             });
 
             function yseEscapeHtml(text) {
@@ -1111,6 +1411,7 @@
                 $.ajax({
                     url : "{% url 'add_transient_comment' %}",
                     type : "POST",
+                    headers : { "X-Requested-With": "XMLHttpRequest" },
                     data : $form.serialize(),
                     success : function(json) {
                         if (json.data) {
@@ -1144,11 +1445,7 @@
             })();
 
 
-            // Submit post on submit (delegated — follow-up form may load via fragment)
-            $(document).on('submit', '#add_transient_followup', function(event){
-                event.preventDefault();
-                add_transient_followup();
-            });
+            // Follow-up submit is wired in the early script block (yseTriggerFollowupSubmit).
 
             function ChangeErr() {
                 alert("Transient Status may not have changed -- please use YSE Admin and contact Dave C or David J.")
@@ -1566,163 +1863,100 @@
                     });
             }
 
-            function add_transient_followup() {
-                // Grab the form, and associate it with the current transient detail page
-                var data = $('#add_transient_followup').serialize()
-                var transient_id = $('#transient_pk').val()
-                data = (data + "&transient=" + transient_id)
+{% if not transient_detail_defer %}
+            window.yseOnTransientFollowupCreated = function(json) {
+                var followup_pk = json.data["id"];
+                var status_id = json.data["status_id"];
+                var status_name = json.data["status_name"];
+                var valid_start = json.data["valid_start"];
+                var valid_stop = json.data["valid_stop"];
+                var modified_by = json.data["modified_by"];
 
-                $.ajax({
-                    url : "{% url 'add_transient_followup' %}", // the endpoint
-                    type : "POST", // http method
-                    data : data, // data sent with the post request
+                if (!followup_pk || !status_id || !status_name ||
+                    !valid_start || !valid_stop || !modified_by) {
+                    alert("Required fields for `Transient Followup` not found! Please contact administrator.");
+                    return;
+                }
 
-                    // handle a successful response
-                    success : function(json) {
+                var too_resource = json.data["too_resource"];
+                var classical_resource = json.data["classical_resource"];
+                var queued_resource = json.data["queued_resource"];
+                var spec_priority = json.data["spec_priority"] ? json.data["spec_priority"] : "None";
+                var phot_priority = json.data["phot_priority"] ? json.data["phot_priority"] : "None";
+                var offset_star_ra = json.data["offset_star_ra"] ? json.data["offset_star_ra"] : "None";
+                var offset_star_dec = json.data["offset_star_dec"] ? json.data["offset_star_dec"] : "None";
+                var offset_north = json.data["offset_north"] ? json.data["offset_north"] : "None";
+                var offset_east = json.data["offset_east"] ? json.data["offset_east"] : "None";
+                var comment = json.data["comment"] ? json.data["comment"] : "None";
 
-                        // Required fields
-                        var followup_pk = json.data["id"]
-                        var status_id = json.data["status_id"]
-                        var status_name = json.data["status_name"]
-                        var valid_start = json.data["valid_start"]
-                        var valid_stop = json.data["valid_stop"]
-                        var modified_by = json.data["modified_by"]
+                var start_date = new Date(valid_start);
+                var end_date = new Date(valid_stop);
+                var start_date_str = (start_date.getUTCMonth() + 1) + "/" + start_date.getUTCDate() + "/" + start_date.getUTCFullYear();
+                var end_date_str = (end_date.getUTCMonth() + 1) + "/" + end_date.getUTCDate() + "/" + end_date.getUTCFullYear();
 
-                        if (!followup_pk || !status_id || !status_name ||
-                            !valid_start || !valid_stop || !modified_by) {
-                            alert("Required fields for `Transient Followup` not found! Please contact administrator. Exiting...")
-                            throw "Missing required fields from ``AddTransientFollowupFormView"
+                var associated_resouces = "";
+                if (too_resource) {
+                    associated_resouces = associated_resouces + too_resource + "<br>";
+                }
+                if (classical_resource) {
+                    associated_resouces = associated_resouces + classical_resource + "<br>";
+                }
+                if (queued_resource) {
+                    associated_resouces = associated_resouces + queued_resource;
+                }
+
+                var followupHTML = "<div class='col-xs-12'>" +
+                    "<div class='followupbox box box-primary'>" +
+                    "<div class='box-header'>" +
+                    "<div class='col-xs-4'><h3 class='box-title'>Follow-up (id: " + followup_pk + ")</h3></div>" +
+                    "<div class='col-xs-4'><h3 class='box-title'>Valid: " + start_date_str + " - " + end_date_str + "</h3></div>" +
+                    "<div class='col-xs-4'><h3 style='float:right;padding-right:10px' class='box-title'>Last Modified: " + modified_by + "</h3></div>" +
+                    "<div class='box-tools pull-right'><button type='button' class='btn btn-box-tool' data-widget='collapse'><i class='fa fa-minus'></i></button></div>" +
+                    "</div><div class='box-body'>" +
+                    "<table id='tbl_followup_" + followup_pk + "' class='table table-bordered table-striped'>" +
+                    "<thead><tr><th>Spec. Priority</th><th>Phot. Priority</th><th>Offset Star<br>RA</th><th>Offset Star<br>DEC</th><th>Offset North</th><th>Offset East</th><th>Attached Resource</th><th>Status</th><th>Comment</th><th>Action</th><th>Delete</th></tr></thead>" +
+                    "<tbody><tr>" +
+                    "<td>" + spec_priority + "</td><td>" + phot_priority + "</td>" +
+                    "<td>" + offset_star_ra + "</td><td>" + offset_star_dec + "</td>" +
+                    "<td>" + offset_north + "</td><td>" + offset_east + "</td>" +
+                    "<td>" + associated_resouces + "</td><td>" + status_name + "</td><td>" + comment + "</td>" +
+                    "<td><a target='_blank' href='{% url 'admin:YSE_App_transientfollowup_changelist' %}" + followup_pk + "/change/'>Edit</a></td>" +
+                    "<td><a href='{% url 'delete_followup' -1 %}".replace('-1', followup_pk) + "'>Delete</a></td>" +
+                    "</tr></tbody></table><hr>" +
+                    "<h4 class='box-title'>Observation Tasks</h4>" +
+                    "<table id='tbl_obs_followup_" + followup_pk + "' class='table table-bordered table-striped'>" +
+                    "<thead><tr><th>ID</th><th>Obs.</th><th>Tel.</th><th>Inst.</th>" +
+                    "<th>Desired Obs.<br>Date (UTC)</th><th>Actual Obs.<br>Date (UTC)</th>" +
+                    "<th>Exp.<br>Time</th><th>Desc.</th><th># of<br>Exposures</th>" +
+                    "<th>Config. Name</th><th>Config. Detail</th><th>Status</th>" +
+                    "<th>Last<br>Modified By</th><th>Action</th></tr></thead>" +
+                    "<tbody><tr><td colspan='13'></td><td><b><a class='add_task' followup_id='" + followup_pk + "' href='#'>Add</a></b></td></tr>" +
+                    "</tbody></table><br></div></div></div>";
+
+                $('#followup_container .text-muted').remove();
+                $('#followup_container .followupbox').each(function() {
+                    var $box = $(this);
+                    $box.addClass('collapsed-box');
+                    $box.find('.box-body').hide();
+                    $box.find('[data-widget=collapse] i').removeClass('fa-minus').addClass('fa-plus');
+                });
+                var $newRow = $(followupHTML).hide();
+                $newRow.find('.box-body').hide();
+                $('#followup_container').prepend($newRow);
+                $newRow.slideDown(300, function() {
+                    $newRow.find('.box-body').slideDown(300, function() {
+                        var $newBox = $newRow.find('.followupbox');
+                        if ($.fn.boxWidget) {
+                            $newBox.boxWidget();
                         }
-
-                        var too_resource = json.data["too_resource"]
-                        var classical_resource = json.data["classical_resource"]
-                        var queued_resource = json.data["queued_resource"]
-
-                        var spec_priority = json.data["spec_priority"] ? json.data["spec_priority"] : "None"
-                        var phot_priority = json.data["phot_priority"] ? json.data["phot_priority"] : "None"
-                        var offset_star_ra = json.data["offset_star_ra"] ? json.data["offset_star_ra"] : "None"
-                        var offset_star_dec = json.data["offset_star_dec"] ? json.data["offset_star_dec"] : "None"
-                        var offset_north = json.data["offset_north"] ? json.data["offset_north"] : "None"
-                        var offset_east = json.data["offset_east"] ? json.data["offset_east"] : "None"
-                        var comment = json.data["comment"] ? json.data["comment"] : "None"
-
-                        // Construct date strings
-                        var start_date = new Date(valid_start)
-                        var end_date = new Date(valid_stop)
-                        var start_date_str = start_date.getUTCMonth() + "/" + start_date.getUTCDate() + "/" + start_date.getUTCFullYear()
-                        var end_date_str = end_date.getUTCMonth() + "/" + end_date.getUTCDate() + "/" + end_date.getUTCFullYear()
-
-                        // Construct associated resources
-                        var associated_resouces = "";
-                        if (too_resource) {
-                            associated_resouces = (associated_resouces + too_resource + "<br>")
-                        }
-                        if (classical_resource) {
-                            associated_resouces = (associated_resouces + classical_resource + "<br>")
-                        }
-                        if (queued_resource) {
-                            associated_resouces = (associated_resouces + queued_resource)
-                        }
-
-                        // Construct HTML to append container
-                        var followupHTML = "<div class='col-xs-12'>" +
-                            "<div class='followupbox box box-primary'>" +
-                            "<div class='box-header'>" +
-                            "<div class='col-xs-4'>" +
-                            "<h3 class='box-title'>Follow-up (id: " + followup_pk + ")</h3>" +
-                            "</div>" +
-                            "<div class='col-xs-4'>" +
-                            "<h3 class='box-title'>Valid: " + start_date_str + " - " + end_date_str + "</h3>" +
-                            "</div>" +
-                            "<div class='col-xs-4'>" +
-                            "<h3 style='float:right;padding-right:10px' class='box-title'>Last Modified: " + modified_by + "</h3>" +
-                            "</div>" +
-                            "<div class='box-tools pull-right'>" +
-                            "<button type='button' class='btn btn-box-tool' data-widget='collapse'><i class='fa fa-minus'></i></button>" +
-                            "</div>" +
-                            "</div>" +
-                            "<div class='box-body'>" +
-                            "<table id='tbl_followup_" + followup_pk + "' class='table table-bordered table-striped'>" +
-                            "<thead><tr><th>Spec. Priority</th><th>Phot. Priority</th><th>Offset Star<br>RA</th><th>Offset Star<br>DEC</th><th>Offset North</th><th>Offset East</th><th>Attached Resource</th><th>Status</th><th>Comment</th><th>Action</th><th>Delete</th></tr></thead>" +
-                            "<tbody><tr>" +
-                            "<td>" + spec_priority + "</td>" +
-                            "<td>" + phot_priority + "</td>" +
-                            "<td>" + offset_star_ra + "</td>" +
-                            "<td>" + offset_star_dec + "</td>" +
-                            "<td>" + offset_north + "</td>" +
-                            "<td>" + offset_east + "</td>" +
-                            "<td>" + associated_resouces + "</td>" +
-                            "<td>" + status_name + "</td>" +
-                            "<td>" + comment + "</td>" +
-                            "<td><a target='_blank' href='{% url 'admin:YSE_App_transientfollowup_changelist' %}" + followup_pk + "/change/'>Edit</a></td>" +
-                            "<td><a href='{% url 'delete_followup' -1 %}".replace('-1', followup_pk) + "'>Delete</a></td>" +
-                            "</tr></tbody></table><hr>" +
-                            "<h4 class='box-title'>Observation Tasks</h4>" +
-                            "<table id='tbl_obs_followup_" + followup_pk + "' class='table table-bordered table-striped'>" +
-                            "<thead><tr>" +
-                            "<th>ID</th>" +
-                            "<th>Obs.</th>" +
-                            "<th>Tel.</th>" +
-                            "<th>Inst.</th>" +
-                            "<th>Desired Obs.<br>Date (UTC)</th>" +
-                            "<th>Actual Obs.<br>Date (UTC)</th>" +
-                            "<th>Exp.<br>Time</th>" +
-                            "<th>Desc.</th>" +
-                            "<th># of<br>Exposures</th>" +
-                            "<th>Config. Name</th>" +
-                            "<th>Config. Detail</th>" +
-                            "<th>Status</th>" +
-                            "<th>Last<br>Modified By</th>" +
-                            "<th>Action</th>" +
-                            "</tr></thead>" +
-                            "<tbody><tr><td colspan='13'></td><td><b><a class='add_task' followup_id='" + followup_pk + "' href='#'>Add</a></b></td></tr>" +
-                            "</tbody></table><br></div></div></div>"
-
-                            var container_collection = $("#followup_container > div")
-                            if (container_collection.length == 0) {
-                                $("#followup_container").append(followupHTML)
-                            } else {
-                                $("#followup_container").prepend(followupHTML)
-                            }
-
-                            // Close & reset form box
-                            $("#add_transient_followup_btn").trigger("click")
-                            $('#add_transient_followup')[0].reset();
-                            yseSyncAudiencePanels($('#add_transient_followup'));
-
-                            // Re-initialize the datepicker
-                            $('#valid_start').val("")
-                            $('#valid_stop').val("")
-                            $('#follow_date_range').daterangepicker({
-                                timePicker24Hour: true,
-                                timePicker: true,
-                                timePickerIncrement: 1,
-                                format: 'MM/DD/YYYY HH:mm',
-                                locale: {
-                                    format: 'MM/DD/YYYY HH:mm'
-                                }
-                            });
-
-                            // Re-Initialize daterange
-                            fdr_picker = $('#follow_date_range').data('daterangepicker')
-                            $('#valid_start').val(fdr_picker.startDate.format("YYYY-MM-DD HH:mm:00"))
-                            $('#valid_stop').val(fdr_picker.endDate.format("YYYY-MM-DD HH:mm:00"))
-
-                            // Re-wire widget behavior
-                            $('.followupbox').boxWidget()
-                            $('.add_task').on('click', function(event){
-                                event.preventDefault();
-                                var followup_id = $(this).attr('followup_id');
-                                ToggleObservationTaskForm(followup_id,true)
-                            });
-                    },
-
-                    // handle a non-successful response
-                    error : function(xhr,errmsg,err) {
-                        alert(xhr.status + ": " + xhr.responseText);
-                    }
+                        $newRow.find('.add_task').on('click', function(event) {
+                            event.preventDefault();
+                            ToggleObservationTaskForm($(this).attr('followup_id'), true);
+                        });
+                    });
                 });
             };
+{% endif %}
 
             // This function gets cookie with a given name
             function getCookie(name) {

--- a/YSE_App/templates/YSE_App/transient_detail.html
+++ b/YSE_App/templates/YSE_App/transient_detail.html
@@ -1060,6 +1060,29 @@
                 add_transient_comment();
             });
 
+            function yseSyncAudiencePanels($root) {
+                $root = $root || $(document);
+                $root.find('.yse-audience-panel').each(function() {
+                    var $panel = $(this);
+                    var $public = $panel.find('.yse-audience-toggle-public');
+                    var $groups = $panel.find('.yse-audience-groups');
+                    if (!$public.length) {
+                        return;
+                    }
+                    var showGroups = !$public.is(':checked');
+                    $groups.toggle(showGroups);
+                    $groups.find('input[type=checkbox]').prop('disabled', !showGroups);
+                });
+            }
+
+            $(document).on('change', '.yse-audience-toggle-public', function() {
+                yseSyncAudiencePanels($(this).closest('.yse-audience-panel'));
+            });
+
+            $(function() {
+                yseSyncAudiencePanels();
+            });
+
             function yseEscapeHtml(text) {
                 return $('<div/>').text(text || '').html();
             }
@@ -1094,6 +1117,7 @@
                             ysePrependCommentRow(json.data);
                         }
                         $form[0].reset();
+                        yseSyncAudiencePanels($form);
                     },
                     error : function(xhr) {
                         alert(xhr.status + ": " + xhr.responseText);
@@ -1113,6 +1137,7 @@
                         var inner = $(html).find('#yse-comments-panel-inner').html();
                         if (inner) {
                             $('#yse-comments-panel-inner').html(inner);
+                            yseSyncAudiencePanels($('#yse-comments-section'));
                         }
                     });
                 }, 60000);
@@ -1663,6 +1688,7 @@
                             // Close & reset form box
                             $("#add_transient_followup_btn").trigger("click")
                             $('#add_transient_followup')[0].reset();
+                            yseSyncAudiencePanels($('#add_transient_followup'));
 
                             // Re-initialize the datepicker
                             $('#valid_start').val("")

--- a/YSE_App/templates/YSE_App/transient_detail/comments_panel.html
+++ b/YSE_App/templates/YSE_App/transient_detail/comments_panel.html
@@ -47,13 +47,13 @@
                         </div>
                         <div id="yse-comment-audience-groups" class="yse-audience-groups">
                             {% if transient_comment_form.show_audience_picker %}
-                                <p class="text-muted small">Collaboration groups (default: groups you share on this transient):</p>
+                                <p class="text-muted small">Restrict to collaboration groups (default: all groups you share on this transient). Uncheck all groups to keep the comment visible only to you.</p>
                                 {% for checkbox in transient_comment_form.audience_groups %}
                                 <div class="checkbox">{{ checkbox }}</div>
                                 {% endfor %}
                             {% else %}
                                 <p class="text-muted small yse-audience-default-note">
-                                    Default: members of your collaboration groups on this transient.
+                                    Default: visible to all YSE users who can open this transient.
                                 </p>
                             {% endif %}
                         </div>

--- a/YSE_App/templates/YSE_App/transient_detail/comments_panel.html
+++ b/YSE_App/templates/YSE_App/transient_detail/comments_panel.html
@@ -37,6 +37,27 @@
                             <button type="submit" class="btn btn-primary btn-block yse-comment-submit">Submit</button>
                         </div>
                     </div>
+                    <div class="yse-audience-panel yse-comment-audience">
+                        <p class="yse-audience-heading text-muted"><strong>Who can see this?</strong></p>
+                        <div class="checkbox yse-audience-public">
+                            <label>
+                                {% render_field transient_comment_form.is_public class+="yse-audience-toggle-public" %}
+                                {{ transient_comment_form.is_public.label }}
+                            </label>
+                        </div>
+                        <div id="yse-comment-audience-groups" class="yse-audience-groups">
+                            {% if transient_comment_form.show_audience_picker %}
+                                <p class="text-muted small">Collaboration groups (default: groups you share on this transient):</p>
+                                {% for checkbox in transient_comment_form.audience_groups %}
+                                <div class="checkbox">{{ checkbox }}</div>
+                                {% endfor %}
+                            {% else %}
+                                <p class="text-muted small yse-audience-default-note">
+                                    Default: members of your collaboration groups on this transient.
+                                </p>
+                            {% endif %}
+                        </div>
+                    </div>
                 </form>
             </div>
         </div>

--- a/YSE_App/tests/fixtures_security_matrix.py
+++ b/YSE_App/tests/fixtures_security_matrix.py
@@ -7,13 +7,23 @@ Magnitude on each point equals its test ID (0 = public, 1 = group A only, …).
 from __future__ import annotations
 
 import datetime
-from typing import Dict, Iterable, List, Optional, Sequence, Set, Tuple
+import re
+from typing import Dict, Iterable, List, Optional, Sequence, Set, Tuple, Type, Union
 
 from django.contrib.auth.models import Group, User
 from django.utils import timezone
 
 from YSE_App.models import (
+    ClassicalObservingDate,
+    ClassicalResource,
+    ClassicalNightType,
+    Observatory,
+    ObservationGroup,
     PhotometricBand,
+    PrincipalInvestigator,
+    QueuedResource,
+    Telescope,
+    ToOResource,
     Transient,
     TransientPhotData,
     TransientPhotometry,
@@ -63,6 +73,14 @@ EXPECTED_MAGS_BY_USER: Dict[str, Set[int]] = {
     "sec_user_b": {0, 2, 5, 7},
     "sec_user_d": {0, 4},
 }
+
+RESOURCE_KINDS: Tuple[Tuple[str, str, Type], ...] = (
+    ("Cls", "classical", ClassicalResource),
+    ("Too", "too", ToOResource),
+    ("Que", "queued", QueuedResource),
+)
+
+_RESOURCE_MAG_RE = re.compile(r"mag(\d+)")
 
 
 def ensure_security_groups() -> Dict[str, Group]:
@@ -143,6 +161,135 @@ def _attach_labeled_series(
     return photometry
 
 
+def _resource_telescope_name(kind_code: str, mag: int, band_suffix: str) -> str:
+    return f"SecVis-{kind_code}-mag{mag}-{band_suffix}"
+
+
+def _resource_mag_from_telescope(telescope_name: str) -> Optional[int]:
+    match = _RESOURCE_MAG_RE.search(telescope_name)
+    if not match:
+        return None
+    return int(match.group(1))
+
+
+def _ensure_secvis_telescope(admin: User, telescope_name: str) -> Telescope:
+    audit = audit_fields(admin)
+    obs_group, _ = ObservationGroup.objects.get_or_create(
+        name=f"secvis-res-{telescope_name}",
+        defaults=audit,
+    )
+    observatory, _ = Observatory.objects.get_or_create(
+        name=f"SecVisObs-{telescope_name}",
+        defaults={"utc_offset": 0, "tz_name": "UTC", **audit},
+    )
+    telescope, _ = Telescope.objects.get_or_create(
+        name=telescope_name,
+        defaults={
+            "observatory": observatory,
+            "latitude": 0.0,
+            "longitude": 0.0,
+            "elevation": 0.0,
+            **audit,
+        },
+    )
+    return telescope
+
+
+def _attach_labeled_resource(
+    admin: User,
+    *,
+    mag: int,
+    group_keys: Sequence[str],
+    band_suffix: str,
+    kind_code: str,
+    kind_label: str,
+    resource_model: Type,
+    groups: Dict[str, Group],
+    principal_investigator: PrincipalInvestigator,
+) -> Union[ClassicalResource, ToOResource, QueuedResource]:
+    audit = audit_fields(admin)
+    telescope_name = _resource_telescope_name(kind_code, mag, band_suffix)
+    telescope = _ensure_secvis_telescope(admin, telescope_name)
+    now = timezone.now()
+    begin = now - datetime.timedelta(days=30)
+    end = now + datetime.timedelta(days=365)
+    description = f"secvis-matrix {kind_label} mag {mag} ({band_suffix})"
+    defaults = {
+        "begin_date_valid": begin,
+        "end_date_valid": end,
+        "description": description,
+        "principal_investigator": principal_investigator,
+        **audit,
+    }
+    if resource_model is ToOResource:
+        defaults.update(
+            {
+                "awarded_too_hours": 20.0,
+                "used_too_hours": 0.0,
+                "awarded_too_triggers": 5.0,
+                "used_too_triggers": 0.0,
+            }
+        )
+    elif resource_model is QueuedResource:
+        defaults.update({"awarded_hours": 40.0, "used_hours": 0.0})
+
+    resource, _ = resource_model.objects.update_or_create(
+        telescope=telescope,
+        defaults=defaults,
+    )
+    resource.groups.clear()
+    for key in group_keys:
+        resource.groups.add(groups[key])
+    if resource_model is ClassicalResource:
+        _ensure_classical_observing_date(admin, resource)
+    return resource
+
+
+def _ensure_classical_observing_date(admin: User, resource: ClassicalResource) -> None:
+    """Observing calendar reads ``ClassicalObservingDate``, not resources alone."""
+    audit = audit_fields(admin)
+    night_type, _ = ClassicalNightType.objects.get_or_create(
+        name="Full",
+        defaults=audit,
+    )
+    begin = resource.begin_date_valid
+    if timezone.is_aware(begin):
+        obs_date = (begin + datetime.timedelta(days=1)).astimezone(datetime.timezone.utc)
+    else:
+        obs_date = begin + datetime.timedelta(days=1)
+    obs_date = obs_date.replace(hour=12, minute=0, second=0, microsecond=0)
+    ClassicalObservingDate.objects.filter(resource=resource).delete()
+    ClassicalObservingDate.objects.create(
+        resource=resource,
+        obs_date=obs_date,
+        night_type=night_type,
+        **audit,
+    )
+
+
+def create_secvis_matrix_resources(admin: User) -> None:
+    """Idempotent: mag-labeled classical / ToO / queued resources for follow-up requests."""
+    groups = ensure_security_groups()
+    audit = audit_fields(admin)
+    pi, _ = PrincipalInvestigator.objects.get_or_create(
+        name="secvis-pi",
+        defaults={"email": "secvis@example.com", **audit},
+    )
+    for mag, group_keys, band_suffix in PHOTOMETRY_SERIES:
+        for kind_code, kind_label, resource_model in RESOURCE_KINDS:
+            _attach_labeled_resource(
+                admin,
+                mag=mag,
+                group_keys=group_keys,
+                band_suffix=band_suffix,
+                kind_code=kind_code,
+                kind_label=kind_label,
+                resource_model=resource_model,
+                groups=groups,
+                principal_investigator=pi,
+            )
+
+
 def create_secvis_matrix_transient(admin: User) -> Transient:
     """Idempotent: one transient with mag-labeled public/private photometry."""
     ensure_transient_statuses(admin)
@@ -165,6 +312,7 @@ def create_secvis_matrix_transient(admin: User) -> Transient:
             band_suffix=band_suffix,
             groups=groups,
         )
+    create_secvis_matrix_resources(admin)
     return transient
 
 
@@ -188,4 +336,27 @@ def authorized_mags_for_user(user: User, transient_id: int) -> Set[int]:
     for row in photdata:
         if row.mag is not None:
             mags.add(int(round(float(row.mag))))
+    return mags
+
+
+def authorized_resource_mags_for_user(
+    user: User,
+    resource_model: Type,
+) -> Set[int]:
+    from YSE_App.data import ObservingResourceService
+
+    if resource_model is ClassicalResource:
+        qs = ObservingResourceService.GetAuthorizedClassicalResource_ByUser(user)
+    elif resource_model is ToOResource:
+        qs = ObservingResourceService.GetAuthorizedToOResource_ByUser(user)
+    elif resource_model is QueuedResource:
+        qs = ObservingResourceService.GetAuthorizedQueuedResource_ByUser(user)
+    else:
+        raise ValueError(f"Unsupported resource model: {resource_model}")
+
+    mags: Set[int] = set()
+    for resource in qs.select_related("telescope"):
+        mag = _resource_mag_from_telescope(resource.telescope.name)
+        if mag is not None:
+            mags.add(mag)
     return mags

--- a/YSE_App/tests/test_audience_ui_v1.py
+++ b/YSE_App/tests/test_audience_ui_v1.py
@@ -39,8 +39,24 @@ class CommentAudienceFormTests(TestCase):
         self.assertIn("sec-group-a", html)
         self.assertIn("sec-group-b", html)
 
-    def test_default_comment_is_private_not_world_public(self):
-        """Private default: not is_public; user with no shared audience group cannot see it."""
+    def test_single_group_users_see_restricted_comment_option(self):
+        """Users with one collaboration group on the transient get an explicit group checkbox."""
+        url = reverse("transient_detail", kwargs={"slug": TRANSIENT_NAME})
+        for username, group_name in (
+            ("sec_user_b", GROUP_NAMES["b"]),
+            ("sec_user_d", GROUP_NAMES["d"]),
+        ):
+            client = Client()
+            client.force_login(self.users[username])
+            response = client.get(url)
+            self.assertEqual(response.status_code, 200, msg=username)
+            html = response.content.decode()
+            self.assertIn("Restrict to collaboration groups", html, msg=username)
+            self.assertIn(group_name, html, msg=username)
+            self.assertIn("id_audience_groups", html, msg=username)
+
+    def test_default_comment_is_private_to_shared_groups(self):
+        """Default form state: shared groups checked, not world-public."""
         client = Client()
         client.force_login(self.user_ab)
         response = client.post(
@@ -48,6 +64,10 @@ class CommentAudienceFormTests(TestCase):
             {
                 "comment": "private AB comment",
                 "transient": self.transient.id,
+                "audience_groups": [
+                    self.groups["a"].pk,
+                    self.groups["b"].pk,
+                ],
             },
             HTTP_X_REQUESTED_WITH="XMLHttpRequest",
         )
@@ -61,10 +81,40 @@ class CommentAudienceFormTests(TestCase):
             transient_comment_queryset(self.transient.id, user=self.user_ab).count(),
             1,
         )
-        # sec_user_d has only group D — no overlap with A/B audience
         user_d = self.users["sec_user_d"]
         self.assertEqual(
             transient_comment_queryset(self.transient.id, user=user_d).count(),
+            0,
+        )
+
+    def test_creator_only_comment_when_no_audience_selected(self):
+        """Unchecked public + unchecked groups => visible only to the author."""
+        client = Client()
+        user_b = self.users["sec_user_b"]
+        client.force_login(user_b)
+        response = client.post(
+            reverse("add_transient_comment"),
+            {
+                "comment": "creator only b",
+                "transient": self.transient.id,
+            },
+            HTTP_X_REQUESTED_WITH="XMLHttpRequest",
+        )
+        self.assertEqual(response.status_code, 200)
+        log = Log.objects.get(transient=self.transient, comment="creator only b")
+        self.assertFalse(log.is_public)
+        self.assertEqual(log.groups.count(), 0)
+
+        self.assertEqual(
+            transient_comment_queryset(self.transient.id, user=user_b).count(),
+            1,
+        )
+        self.assertEqual(
+            transient_comment_queryset(self.transient.id, user=self.user_ab).count(),
+            0,
+        )
+        self.assertEqual(
+            transient_comment_queryset(self.transient.id, user=self.user_ac).count(),
             0,
         )
 
@@ -156,6 +206,36 @@ class CommentAudienceApiTests(TestCase):
             0,
         )
 
+    def test_api_create_creator_only_comment_with_empty_audience_group_ids(self):
+        client = Client()
+        client.force_login(self.user_ab)
+        url = reverse(
+            "api-transient-comments",
+            kwargs={"transient_id": self.transient.id},
+        )
+        response = client.post(
+            url,
+            {
+                "comment": "api creator only",
+                "transient": self.transient.id,
+                "is_public": False,
+                "audience_group_ids": [],
+            },
+            content_type="application/json",
+        )
+        self.assertEqual(response.status_code, 201, response.content)
+        log = Log.objects.get(transient=self.transient, comment="api creator only")
+        self.assertFalse(log.is_public)
+        self.assertEqual(log.groups.count(), 0)
+        self.assertEqual(
+            transient_comment_queryset(self.transient.id, user=self.user_ab).count(),
+            1,
+        )
+        self.assertEqual(
+            transient_comment_queryset(self.transient.id, user=self.user_ac).count(),
+            0,
+        )
+
 
 class FollowupAudienceFormTests(TestCase):
     @classmethod
@@ -164,6 +244,14 @@ class FollowupAudienceFormTests(TestCase):
         cls.user_ab = cls.users["sec_user_ab"]
         cls.user_ac = cls.users["sec_user_ac"]
         cls.groups = ensure_security_groups()
+        from YSE_App.common.collaboration_groups import (
+            ensure_user_has_public_group,
+            get_or_create_public_group,
+        )
+
+        cls.public_group = get_or_create_public_group()
+        for user in cls.users.values():
+            ensure_user_has_public_group(user)
         from YSE_App.models import FollowupStatus
 
         cls.status, _ = FollowupStatus.objects.get_or_create(
@@ -172,6 +260,20 @@ class FollowupAudienceFormTests(TestCase):
                 "created_by": cls.users["sec_user_ab"],
                 "modified_by": cls.users["sec_user_ab"],
             },
+        )
+
+    def _eligible_group_pks(self, user, resource):
+        from YSE_App.services.audience import eligible_followup_audience_groups
+
+        return [
+            group.pk for group in eligible_followup_audience_groups(user, resource)
+        ]
+
+    def _classical_resource(self, mag: int, band_suffix: str):
+        from YSE_App.models import ClassicalResource
+
+        return ClassicalResource.objects.get(
+            telescope__name=f"SecVis-Cls-mag{mag}-{band_suffix}"
         )
 
     def _post_followup(self, user, data):
@@ -194,22 +296,147 @@ class FollowupAudienceFormTests(TestCase):
             HTTP_X_REQUESTED_WITH="XMLHttpRequest",
         )
 
-    def test_default_followup_is_public(self):
-        response = self._post_followup(self.user_ab, {"is_public": "on"})
-        self.assertEqual(response.status_code, 200)
-        followup = TransientFollowup.objects.filter(transient=self.transient).latest("id")
-        self.assertTrue(followup.is_public)
-        self.assertTrue(followup_visible_to_user(self.user_ac, followup))
-
-    def test_restricted_followup_hidden_from_other_group(self):
+    def test_default_followup_selects_eligible_groups(self):
+        resource = self._classical_resource(0, "public")
+        eligible = self._eligible_group_pks(self.user_ab, resource)
         response = self._post_followup(
             self.user_ab,
             {
-                "audience_groups": [self.groups["b"].pk],
+                "classical_resource": resource.pk,
+                "audience_groups": eligible,
             },
         )
         self.assertEqual(response.status_code, 200)
         followup = TransientFollowup.objects.filter(transient=self.transient).latest("id")
+        self.assertFalse(followup.is_public)
+        self.assertEqual(
+            set(followup.groups.values_list("pk", flat=True)),
+            set(eligible),
+        )
+        self.assertTrue(followup_visible_to_user(self.user_ac, followup))
+
+    def test_public_group_followup_on_public_resource(self):
+        resource = self._classical_resource(0, "public")
+        response = self._post_followup(
+            self.user_ab,
+            {
+                "classical_resource": resource.pk,
+                "audience_groups": [self.public_group.pk],
+            },
+        )
+        self.assertEqual(response.status_code, 200)
+        followup = TransientFollowup.objects.filter(
+            transient=self.transient,
+            classical_resource=resource,
+        ).latest("id")
+        self.assertEqual(
+            set(followup.groups.values_list("name", flat=True)),
+            {"Public"},
+        )
+        self.assertTrue(followup_visible_to_user(self.user_ac, followup))
+
+    def test_empty_groups_rejected_without_creator_only_resource(self):
+        from YSE_App.models import ClassicalResource
+
+        resource = ClassicalResource.objects.get(telescope__name="SecVis-Cls-mag2-grpB")
+        response = self._post_followup(
+            self.users["sec_user_b"],
+            {
+                "classical_resource": resource.pk,
+                "audience_groups": [],
+            },
+        )
+        self.assertEqual(response.status_code, 400)
+        self.assertIn("audience_groups", response.json())
+
+    def test_creator_only_followup_visible_to_requester_on_transient_detail(self):
+        """Requester always sees their follow-up row when filtered for the transient."""
+        from YSE_App.models import ClassicalResource, TransientFollowup
+        from YSE_App.services.visibility import filter_transient_followups_for_user
+
+        resource = ClassicalResource.objects.get(telescope__name="SecVis-Cls-mag2-grpB")
+        user_b = self.users["sec_user_b"]
+        response = self._post_followup(
+            user_b,
+            {
+                "classical_resource": resource.pk,
+                "audience_groups": [self.groups["b"].pk],
+            },
+        )
+        self.assertEqual(response.status_code, 200)
+        followup = TransientFollowup.objects.filter(
+            transient=self.transient,
+            requested_by=user_b,
+        ).latest("id")
+        visible = filter_transient_followups_for_user(
+            TransientFollowup.objects.filter(transient=self.transient),
+            user_b,
+        )
+        self.assertIn(
+            followup.id,
+            list(visible.values_list("id", flat=True)),
+        )
+
+    def test_public_group_rejected_on_restricted_resource(self):
+        from YSE_App.models import ClassicalResource
+
+        resource = ClassicalResource.objects.get(telescope__name="SecVis-Cls-mag2-grpB")
+        response = self._post_followup(
+            self.user_ab,
+            {
+                "classical_resource": resource.pk,
+                "audience_groups": [self.public_group.pk, self.groups["b"].pk],
+            },
+        )
+        self.assertEqual(response.status_code, 400)
+        self.assertIn("audience_groups", response.json())
+
+    def test_classical_followup_without_explicit_date_range(self):
+        """Classical-only requests derive valid_start/stop from the resource."""
+        from YSE_App.models import ClassicalResource
+
+        resource = ClassicalResource.objects.get(
+            telescope__name="SecVis-Cls-mag0-public",
+        )
+        client = Client()
+        client.force_login(self.users["sec_user_d"])
+        response = client.post(
+            reverse("add_transient_followup"),
+            {
+                "status": self.status.pk,
+                "transient": self.transient.pk,
+                "classical_resource": resource.pk,
+                "comment": "testing public from d",
+                "audience_groups": self._eligible_group_pks(self.users["sec_user_d"], resource),
+            },
+            HTTP_X_REQUESTED_WITH="XMLHttpRequest",
+        )
+        self.assertEqual(response.status_code, 200, response.content)
+        followup = TransientFollowup.objects.filter(
+            transient=self.transient,
+            classical_resource=resource,
+        ).latest("id")
+        self.assertEqual(followup.valid_start, resource.begin_date_valid)
+        self.assertEqual(followup.valid_stop, resource.end_date_valid)
+        self.assertFalse(followup.is_public)
+        self.assertGreater(followup.groups.count(), 0)
+
+    def test_restricted_followup_hidden_from_other_group(self):
+        from YSE_App.models import ClassicalResource
+
+        resource = ClassicalResource.objects.get(telescope__name="SecVis-Cls-mag2-grpB")
+        response = self._post_followup(
+            self.user_ab,
+            {
+                "classical_resource": resource.pk,
+                "audience_groups": [self.groups["b"].pk],
+            },
+        )
+        self.assertEqual(response.status_code, 200)
+        followup = TransientFollowup.objects.filter(
+            transient=self.transient,
+            classical_resource=resource,
+        ).latest("id")
         self.assertFalse(followup.is_public)
         self.assertEqual(
             set(followup.groups.values_list("name", flat=True)),
@@ -222,3 +449,50 @@ class FollowupAudienceFormTests(TestCase):
             self.user_ac,
         )
         self.assertEqual(qs.count(), 0)
+
+    def test_legacy_public_followup_on_restricted_resource_hidden_from_other_users(self):
+        """``is_public=True`` legacy rows still require linked resource visibility."""
+        from YSE_App.models import ClassicalResource
+
+        resource = ClassicalResource.objects.get(telescope__name="SecVis-Cls-mag4-grpD")
+        user_d = self.users["sec_user_d"]
+        followup = TransientFollowup.objects.create(
+            transient=self.transient,
+            classical_resource=resource,
+            status=self.status,
+            valid_start=resource.begin_date_valid,
+            valid_stop=resource.end_date_valid,
+            is_public=True,
+            requested_by=user_d,
+            created_by=user_d,
+            modified_by=user_d,
+        )
+        self.assertFalse(followup_visible_to_user(self.user_ab, followup))
+        qs = filter_transient_followups_for_user(
+            TransientFollowup.objects.filter(classical_resource=resource),
+            self.user_ab,
+        )
+        self.assertEqual(qs.count(), 0)
+
+    def test_followup_page_hides_unauthorized_telescope_sections(self):
+        from YSE_App.models import ClassicalResource
+
+        resource = ClassicalResource.objects.get(telescope__name="SecVis-Cls-mag4-grpD")
+        user_d = self.users["sec_user_d"]
+        TransientFollowup.objects.create(
+            transient=self.transient,
+            classical_resource=resource,
+            status=self.status,
+            valid_start=resource.begin_date_valid,
+            valid_stop=resource.end_date_valid,
+            is_public=True,
+            requested_by=user_d,
+            created_by=user_d,
+            modified_by=user_d,
+        )
+        client = Client()
+        client.force_login(self.user_ab)
+        response = client.get(reverse("followup"))
+        self.assertEqual(response.status_code, 200)
+        html = response.content.decode()
+        self.assertNotIn("SecVis-Cls-mag4-grpD", html)

--- a/YSE_App/tests/test_audience_ui_v1.py
+++ b/YSE_App/tests/test_audience_ui_v1.py
@@ -1,0 +1,224 @@
+"""v1 create-time audience controls for comments and follow-ups."""
+
+from __future__ import annotations
+
+from django.contrib.auth.models import Group
+from django.test import Client, TestCase
+from django.urls import reverse
+from YSE_App.models import Log, TransientFollowup
+from YSE_App.services.comments import transient_comment_queryset
+from YSE_App.services.visibility import (
+    filter_transient_followups_for_user,
+    followup_visible_to_user,
+)
+from YSE_App.tests.fixtures_security_matrix import (
+    GROUP_NAMES,
+    TRANSIENT_NAME,
+    ensure_security_groups,
+    seed_security_test_matrix,
+)
+
+class CommentAudienceFormTests(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.transient, cls.users = seed_security_test_matrix()
+        cls.groups = ensure_security_groups()
+        cls.user_ab = cls.users["sec_user_ab"]
+        cls.user_ac = cls.users["sec_user_ac"]
+        cls.group_b = cls.groups["b"]
+
+    def test_comment_form_shows_audience_controls(self):
+        client = Client()
+        client.force_login(self.user_ab)
+        url = reverse("transient_detail", kwargs={"slug": TRANSIENT_NAME})
+        response = client.get(url)
+        self.assertEqual(response.status_code, 200)
+        html = response.content.decode()
+        self.assertIn("Who can see this?", html)
+        self.assertIn("id_is_public", html)
+        self.assertIn("sec-group-a", html)
+        self.assertIn("sec-group-b", html)
+
+    def test_default_comment_is_private_not_world_public(self):
+        """Private default: not is_public; user with no shared audience group cannot see it."""
+        client = Client()
+        client.force_login(self.user_ab)
+        response = client.post(
+            reverse("add_transient_comment"),
+            {
+                "comment": "private AB comment",
+                "transient": self.transient.id,
+            },
+            HTTP_X_REQUESTED_WITH="XMLHttpRequest",
+        )
+        self.assertEqual(response.status_code, 200)
+        log = Log.objects.get(transient=self.transient, comment="private AB comment")
+        self.assertFalse(log.is_public)
+        group_names = set(log.groups.values_list("name", flat=True))
+        self.assertEqual(group_names, {GROUP_NAMES["a"], GROUP_NAMES["b"]})
+
+        self.assertEqual(
+            transient_comment_queryset(self.transient.id, user=self.user_ab).count(),
+            1,
+        )
+        # sec_user_d has only group D — no overlap with A/B audience
+        user_d = self.users["sec_user_d"]
+        self.assertEqual(
+            transient_comment_queryset(self.transient.id, user=user_d).count(),
+            0,
+        )
+
+    def test_public_comment_visible_to_other_authorized_user(self):
+        client = Client()
+        client.force_login(self.user_ab)
+        client.post(
+            reverse("add_transient_comment"),
+            {
+                "comment": "public to collaborators",
+                "transient": self.transient.id,
+                "is_public": "on",
+            },
+            HTTP_X_REQUESTED_WITH="XMLHttpRequest",
+        )
+        log = Log.objects.get(transient=self.transient, comment="public to collaborators")
+        self.assertTrue(log.is_public)
+        self.assertEqual(log.groups.count(), 0)
+
+        qs_ac = transient_comment_queryset(self.transient.id, user=self.user_ac)
+        self.assertEqual(qs_ac.count(), 1)
+
+    def test_restricted_comment_to_single_group(self):
+        client = Client()
+        client.force_login(self.user_ab)
+        client.post(
+            reverse("add_transient_comment"),
+            {
+                "comment": "group B only",
+                "transient": self.transient.id,
+                "audience_groups": [self.group_b.pk],
+            },
+            HTTP_X_REQUESTED_WITH="XMLHttpRequest",
+        )
+        log = Log.objects.get(transient=self.transient, comment="group B only")
+        self.assertFalse(log.is_public)
+        self.assertEqual(
+            set(log.groups.values_list("name", flat=True)),
+            {GROUP_NAMES["b"]},
+        )
+        self.assertEqual(
+            transient_comment_queryset(self.transient.id, user=self.user_ab).count(),
+            1,
+        )
+        self.assertEqual(
+            transient_comment_queryset(self.transient.id, user=self.user_ac).count(),
+            0,
+        )
+
+
+class CommentAudienceApiTests(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.transient, cls.users = seed_security_test_matrix()
+        cls.user_ab = cls.users["sec_user_ab"]
+        cls.user_ac = cls.users["sec_user_ac"]
+        cls.groups = ensure_security_groups()
+
+    def test_api_create_private_comment_with_audience_group_ids(self):
+        client = Client()
+        client.force_login(self.user_ab)
+        url = reverse(
+            "api-transient-comments",
+            kwargs={"transient_id": self.transient.id},
+        )
+        response = client.post(
+            url,
+            {
+                "comment": "api private B only",
+                "transient": self.transient.id,
+                "is_public": False,
+                "audience_group_ids": [self.groups["b"].pk],
+            },
+            content_type="application/json",
+        )
+        self.assertEqual(response.status_code, 201, response.content)
+        log = Log.objects.get(transient=self.transient, comment="api private B only")
+        self.assertFalse(log.is_public)
+        self.assertEqual(
+            set(log.groups.values_list("name", flat=True)),
+            {GROUP_NAMES["b"]},
+        )
+        self.assertEqual(
+            transient_comment_queryset(self.transient.id, user=self.user_ab).count(),
+            1,
+        )
+        self.assertEqual(
+            transient_comment_queryset(self.transient.id, user=self.user_ac).count(),
+            0,
+        )
+
+
+class FollowupAudienceFormTests(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.transient, cls.users = seed_security_test_matrix()
+        cls.user_ab = cls.users["sec_user_ab"]
+        cls.user_ac = cls.users["sec_user_ac"]
+        cls.groups = ensure_security_groups()
+        from YSE_App.models import FollowupStatus
+
+        cls.status, _ = FollowupStatus.objects.get_or_create(
+            name="sec-aud-requested",
+            defaults={
+                "created_by": cls.users["sec_user_ab"],
+                "modified_by": cls.users["sec_user_ab"],
+            },
+        )
+
+    def _post_followup(self, user, data):
+        client = Client()
+        client.force_login(user)
+        from django.utils import timezone
+        from datetime import timedelta
+
+        now = timezone.now()
+        payload = {
+            "status": self.status.pk,
+            "transient": self.transient.pk,
+            "valid_start": now.isoformat(),
+            "valid_stop": (now + timedelta(days=2)).isoformat(),
+        }
+        payload.update(data)
+        return client.post(
+            reverse("add_transient_followup"),
+            payload,
+            HTTP_X_REQUESTED_WITH="XMLHttpRequest",
+        )
+
+    def test_default_followup_is_public(self):
+        response = self._post_followup(self.user_ab, {"is_public": "on"})
+        self.assertEqual(response.status_code, 200)
+        followup = TransientFollowup.objects.filter(transient=self.transient).latest("id")
+        self.assertTrue(followup.is_public)
+        self.assertTrue(followup_visible_to_user(self.user_ac, followup))
+
+    def test_restricted_followup_hidden_from_other_group(self):
+        response = self._post_followup(
+            self.user_ab,
+            {
+                "audience_groups": [self.groups["b"].pk],
+            },
+        )
+        self.assertEqual(response.status_code, 200)
+        followup = TransientFollowup.objects.filter(transient=self.transient).latest("id")
+        self.assertFalse(followup.is_public)
+        self.assertEqual(
+            set(followup.groups.values_list("name", flat=True)),
+            {GROUP_NAMES["b"]},
+        )
+        self.assertTrue(followup_visible_to_user(self.user_ab, followup))
+        self.assertFalse(followup_visible_to_user(self.user_ac, followup))
+        qs = filter_transient_followups_for_user(
+            TransientFollowup.objects.filter(transient=self.transient),
+            self.user_ac,
+        )
+        self.assertEqual(qs.count(), 0)

--- a/YSE_App/tests/test_group_visibility.py
+++ b/YSE_App/tests/test_group_visibility.py
@@ -68,6 +68,25 @@ class GroupVisibilityTests(TestCase):
             list(filter_transient_comments_for_user(Log.objects.all(), self.user_a)),
         )
 
+    def test_creator_only_comment_visible_only_to_author(self):
+        log = create_transient_comment(
+            transient=self.transient,
+            comment="only me",
+            user=self.user_a,
+            notify=False,
+            is_public=False,
+            audience_groups=[],
+        )
+        self.assertEqual(log.groups.count(), 0)
+        self.assertEqual(
+            transient_comment_queryset(self.transient.id, user=self.user_a).count(),
+            1,
+        )
+        self.assertEqual(
+            transient_comment_queryset(self.transient.id, user=self.user_b).count(),
+            0,
+        )
+
     def test_public_comment_visible_to_authorized_user(self):
         create_transient_comment(
             transient=self.transient,

--- a/YSE_App/tests/test_performance.py
+++ b/YSE_App/tests/test_performance.py
@@ -35,7 +35,7 @@ from YSE_App.tests.perf_tracking import LoadTimeRegistry
 
 # Query ceilings — tighten as views are optimized.
 MAX_QUERIES_TRANSIENT_DETAIL_SHELL = 50
-MAX_QUERIES_TRANSIENT_DETAIL_LOADED = 72
+MAX_QUERIES_TRANSIENT_DETAIL_LOADED = 90  # audience form loads shared collaboration groups
 MAX_QUERIES_PERSONAL_DASHBOARD = 40
 # Cold: five explorer SQL runs + five table builds (heavy; ceiling guards regressions).
 MAX_QUERIES_PERSONAL_DASHBOARD_FIVE_QUERIES_COLD = 28
@@ -168,7 +168,7 @@ class TransientDetailPagePerformanceTests(TestCase):
             response=response,
             n_queries=n_queries,
             elapsed=elapsed,
-            max_queries=40,
+            max_queries=46,
             max_seconds=6.0,
         )
 

--- a/YSE_App/tests/test_phase2_comments.py
+++ b/YSE_App/tests/test_phase2_comments.py
@@ -3,6 +3,7 @@
 import hashlib
 import hmac
 import json
+import os
 import time
 from unittest.mock import patch
 
@@ -36,6 +37,22 @@ class Phase2CommentTests(TestCase):
         self.assertIn("yse-comment-thread", html)
         self.assertNotIn('id="comments_tab"', html)
 
+    @patch.dict(os.environ, {"YSE_TRANSIENT_DETAIL_DEFER": "1"})
+    def test_deferred_transient_detail_renders_saved_comments(self):
+        Log.objects.filter(transient=self.transient).delete()
+        create_transient_comment(
+            transient=self.transient,
+            comment="visible on deferred shell",
+            user=self.user,
+            notify=False,
+        )
+        url = reverse("transient_detail", kwargs={"slug": self.transient.slug})
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+        html = response.content.decode()
+        self.assertIn("visible on deferred shell", html)
+        self.assertNotIn("No comments yet.", html)
+
     def test_comments_fragment_returns_panel(self):
         url = reverse("comments_fragment", kwargs={"slug": self.transient.slug})
         response = self.client.get(url)
@@ -57,6 +74,28 @@ class Phase2CommentTests(TestCase):
         self.assertIn("comment", data["data"])
         self.assertEqual(
             Log.objects.filter(transient=self.transient).count(),
+            1,
+        )
+
+    def test_add_transient_comment_non_ajax_redirects_to_transient_detail(self):
+        Log.objects.filter(transient=self.transient).delete()
+        response = self.client.post(
+            reverse("add_transient_comment"),
+            {
+                "comment": "Non-AJAX fallback comment",
+                "transient": self.transient.id,
+            },
+        )
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(
+            response["Location"],
+            reverse("transient_detail", kwargs={"slug": self.transient.slug}),
+        )
+        self.assertEqual(
+            Log.objects.filter(
+                transient=self.transient,
+                comment="Non-AJAX fallback comment",
+            ).count(),
             1,
         )
 

--- a/YSE_App/tests/test_security_matrix_resources.py
+++ b/YSE_App/tests/test_security_matrix_resources.py
@@ -1,0 +1,112 @@
+"""Security matrix: group-labeled observing resources for follow-up requests."""
+
+import re
+
+from django.test import Client, TestCase
+from django.urls import reverse
+
+from YSE_App.models import ClassicalObservingDate, ClassicalResource, QueuedResource, ToOResource
+from YSE_App.tests.fixtures_security_matrix import (
+    EXPECTED_MAGS_BY_USER,
+    TRANSIENT_NAME,
+    authorized_resource_mags_for_user,
+    seed_security_test_matrix,
+)
+
+
+class SecurityMatrixResourceTests(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.transient, cls.users = seed_security_test_matrix()
+
+    def test_each_resource_kind_seeded_for_all_series(self):
+        for resource_model in (ClassicalResource, ToOResource, QueuedResource):
+            with self.subTest(model=resource_model.__name__):
+                self.assertEqual(
+                    resource_model.objects.filter(
+                        description__startswith="secvis-matrix"
+                    ).count(),
+                    8,
+                )
+
+    def test_authorized_classical_resources_per_user(self):
+        for username, expected in EXPECTED_MAGS_BY_USER.items():
+            user = self.users[username]
+            with self.subTest(user=username, kind="classical"):
+                mags = authorized_resource_mags_for_user(user, ClassicalResource)
+                self.assertEqual(mags, expected)
+
+    def test_authorized_too_resources_per_user(self):
+        for username, expected in EXPECTED_MAGS_BY_USER.items():
+            user = self.users[username]
+            with self.subTest(user=username, kind="too"):
+                mags = authorized_resource_mags_for_user(user, ToOResource)
+                self.assertEqual(mags, expected)
+
+    def test_authorized_queued_resources_per_user(self):
+        for username, expected in EXPECTED_MAGS_BY_USER.items():
+            user = self.users[username]
+            with self.subTest(user=username, kind="queued"):
+                mags = authorized_resource_mags_for_user(user, QueuedResource)
+                self.assertEqual(mags, expected)
+
+    def test_classical_observing_dates_idempotent_on_reseed(self):
+        classical = ClassicalResource.objects.filter(
+            description__startswith="secvis-matrix",
+            telescope__name__startswith="SecVis-Cls-",
+        )
+        seed_security_test_matrix()
+        self.assertEqual(
+            ClassicalObservingDate.objects.filter(resource__in=classical).count(),
+            8,
+        )
+
+    def test_observing_calendar_shows_only_authorized_runs(self):
+        client = Client()
+        url = reverse("observing_calendar")
+
+        client.force_login(self.users["sec_user_ab"])
+        response = client.get(url)
+        self.assertEqual(response.status_code, 200)
+        html = response.content.decode()
+        self.assertIn("SecVis-Cls-mag1-grpA", html)
+        self.assertNotIn("SecVis-Cls-mag4-grpD", html)
+
+        client.force_login(self.users["sec_user_d"])
+        response = client.get(url)
+        html = response.content.decode()
+        self.assertIn("SecVis-Cls-mag4-grpD", html)
+        self.assertNotIn("SecVis-Cls-mag2-grpB", html)
+
+    def _select_options_html(self, html: str, field_id: str) -> str:
+        match = re.search(
+            rf'id="{field_id}"[^>]*>(.*?)</select>',
+            html,
+            re.DOTALL,
+        )
+        self.assertIsNotNone(match, msg=f"Missing select#{field_id}")
+        return match.group(1)
+
+    def test_followup_fragment_lists_only_authorized_classical_resources(self):
+        url = reverse(
+            "transient_detail_followup_rest_fragment",
+            kwargs={"transient_id": self.transient.id},
+        )
+        client = Client()
+        client.force_login(self.users["sec_user_b"])
+        response = client.get(url)
+        self.assertEqual(response.status_code, 200)
+        html = response.content.decode()
+        classical_options = self._select_options_html(html, "id_classical_resource")
+        too_options = self._select_options_html(html, "id_too_resource")
+        self.assertIn("SecVis-Cls-mag2-grpB", classical_options)
+        self.assertNotIn("SecVis-Cls-mag1-grpA", classical_options)
+        self.assertIn("SecVis-Too-mag0-public", too_options)
+        self.assertNotIn("SecVis-Too-mag1-grpA", too_options)
+
+        client.force_login(self.users["sec_user_d"])
+        response = client.get(url)
+        html = response.content.decode()
+        classical_options = self._select_options_html(html, "id_classical_resource")
+        self.assertIn("SecVis-Cls-mag4-grpD", classical_options)
+        self.assertNotIn("SecVis-Cls-mag2-grpB", classical_options)

--- a/YSE_App/views.py
+++ b/YSE_App/views.py
@@ -551,17 +551,25 @@ def followup(request):
     followup_transients = None
 
     telescopes = Telescope.objects.all()
+    from YSE_App.services.visibility import filter_transient_followups_for_user
 
     table_list = []
     for t in telescopes:
         followup_transients = TransientFollowup.objects.filter(Q(too_resource__telescope__name=t) |
                                                                Q(classical_resource__telescope__name=t) |
                                                                Q(queued_resource__telescope__name=t))
+        followup_transients = filter_transient_followups_for_user(
+            followup_transients,
+            request.user,
+        )
         followuptransientfilter = FollowupFilter(request.GET, queryset=followup_transients,prefix=t)
         
+        if not followuptransientfilter.qs.exists():
+            continue
+
         followup_table = FollowupTable(followuptransientfilter.qs,prefix=t)
         RequestConfig(request, paginate={'per_page': 10}).configure(followup_table)
-        table_list += [(t.name,followup_table,t.name.replace(' ','_'),followup_transients,followuptransientfilter)]
+        table_list += [(t.name,followup_table,t.name.replace(' ','_'),followuptransientfilter.qs,followuptransientfilter)]
 
     if request.META['QUERY_STRING']:
         anchor = request.META['QUERY_STRING'].split('-ex')[0]
@@ -667,7 +675,10 @@ def yse_oncall_calendar(request):
 
 @login_required
 def observing_calendar(request):
-    all_dates = ClassicalObservingDate.objects.all().select_related()
+    from YSE_App.data.ObservingResourceService import (
+        GetAuthorizedClassicalObservingDate_ByUser,
+    )
+
     colors = ['#dd4b39', 
                 '#f39c12', 
                 '#00c0ef', 
@@ -678,9 +689,18 @@ def observing_calendar(request):
                 '#d2d6de',
                 '#001f3f']
 
+    all_dates = (
+        GetAuthorizedClassicalObservingDate_ByUser(request.user)
+        .select_related("resource", "resource__telescope", "resource__principal_investigator")
+    )
+
     telescope_colors = {}
-    for i, c in enumerate(ClassicalResource.objects.all().select_related()):
-        telescope_colors[c.telescope.name] = colors[i % len(colors)]
+    seen_telescopes = set()
+    for date in all_dates:
+        tel_name = date.resource.telescope.name
+        if tel_name not in seen_telescopes:
+            telescope_colors[tel_name] = colors[len(seen_telescopes) % len(colors)]
+            seen_telescopes.add(tel_name)
 
     context = {
         'all_dates': all_dates,
@@ -1244,22 +1264,9 @@ def _load_transient_followups(transient_id, user):
 
 def _transient_followup_form_context(request, transient_obj):
     """Forms and authorized querysets for follow-up tab fragments."""
-    from django.utils import timezone
-
     transient_followup_form = TransientFollowupForm(
         user=request.user,
         transient_id=transient_obj.id,
-    )
-    valid_after = timezone.now() - datetime.timedelta(days=1)
-    transient_followup_form.fields["too_resource"].queryset = (
-        view_utils.get_authorized_too_resources(request.user)
-        .filter(end_date_valid__gt=valid_after)
-        .order_by('telescope__name')
-    )
-    transient_followup_form.fields["queued_resource"].queryset = (
-        view_utils.get_authorized_queued_resources(request.user)
-        .filter(end_date_valid__gt=valid_after)
-        .order_by('telescope__name')
     )
     ctx = {
         'transient': transient_obj,
@@ -1562,19 +1569,9 @@ def transient_detail(request, slug):
             )
 
         comment_cutoff = timezone.now() - datetime.timedelta(1)
-        if defer_detail:
-            logs = []
-            has_new_comment = Log.objects.filter(
-                transient_id=transient_id,
-                modified_date__gt=comment_cutoff,
-            ).exists()
-        else:
-            logs = list(
-                Log.objects.filter(transient_id=transient_id).order_by('-modified_date')
-            )
-            has_new_comment = any(
-                log.modified_date > comment_cutoff for log in logs
-            )
+        has_new_comment = any(
+            log.modified_date > comment_cutoff for log in logs
+        )
         
         date = datetime.datetime.now(tz=pytz.utc)
         date_format='%m/%d/%Y %H:%M:%S'

--- a/YSE_App/views.py
+++ b/YSE_App/views.py
@@ -1246,7 +1246,10 @@ def _transient_followup_form_context(request, transient_obj):
     """Forms and authorized querysets for follow-up tab fragments."""
     from django.utils import timezone
 
-    transient_followup_form = TransientFollowupForm()
+    transient_followup_form = TransientFollowupForm(
+        user=request.user,
+        transient_id=transient_obj.id,
+    )
     valid_after = timezone.now() - datetime.timedelta(days=1)
     transient_followup_form.fields["too_resource"].queryset = (
         view_utils.get_authorized_too_resources(request.user)
@@ -1448,7 +1451,10 @@ def transient_detail(request, slug):
         alt_names = AlternateTransientNames.objects.filter(transient__pk=transient_id)
 
         if defer_detail:
-            transient_followup_form = TransientFollowupForm()
+            transient_followup_form = TransientFollowupForm(
+                user=request.user,
+                transient_id=transient_id,
+            )
             transient_observation_task_form = TransientObservationTaskForm()
             classical_resource_form = ClassicalResourceForm()
             too_resource_form = ToOResourceForm()
@@ -1470,7 +1476,10 @@ def transient_detail(request, slug):
         transient_status_watch = status_by_name.get("Watch")
         transient_status_interesting = status_by_name.get("Interesting")
         transient_status_ignore = status_by_name.get("Ignore")
-        transient_comment_form = TransientCommentForm()
+        transient_comment_form = TransientCommentForm(
+            user=request.user,
+            transient_id=transient_id,
+        )
         # Transient tag
         all_colors = WebAppColor.objects.all().select_related()
         all_transient_tags = TransientTag.objects.all().select_related()
@@ -1686,7 +1695,11 @@ def comments_fragment(request, slug):
 
     comment_cutoff = dj_timezone.now() - datetime.timedelta(days=1)
     has_new_comment = any(log.modified_date > comment_cutoff for log in logs)
-    form = TransientCommentForm(initial={"transient": transient.id})
+    form = TransientCommentForm(
+        user=request.user,
+        transient_id=transient.id,
+        initial={"transient": transient.id},
+    )
     return render(
         request,
         "YSE_App/transient_detail/comments_panel.html",

--- a/docs/security-groups.md
+++ b/docs/security-groups.md
@@ -52,6 +52,25 @@ docker exec ysepz_web_container python3 manage.py mark_tns_imports_public
 
 Tests: `YSE_App.tests.test_tns_import_groups`.
 
+### v1 create-time audience UI
+
+Comments (Summary tab) and follow-up requests expose **Who can see this?** controls at submit time:
+
+- **Comments:** default private to collaboration groups you share on this transient; opt-in checkbox “Visible to all YSE users who can open this transient”. When you belong to multiple groups, checkboxes list which groups may read the comment.
+- **Follow-ups:** default public (checkbox checked); uncheck to restrict to selected collaboration groups.
+
+Automated tests: `YSE_App.tests.test_audience_ui_v1`.
+
+#### Manual checks (audience UI)
+
+1. Seed matrix: `python3 manage.py seed_security_test_matrix`
+2. As `sec_user_ab` / `sec-test-pass`, open `/transient_detail/secvis-matrix/`
+3. **Comment — default private:** post “test private AB” with no audience checkbox. Log in as `sec_user_d` — comment must **not** appear (no shared group). Log in as `sec_user_ab` — comment **must** appear. Log in as `sec_user_ac` — **may** appear (shares group A with the audience).
+4. **Comment — public:** as `sec_user_ab`, check “Visible to all YSE users…”, post “test public”. As `sec_user_ac`, comment **must** appear.
+5. **Comment — group B only:** as `sec_user_ab`, uncheck public, select only `sec-group-b`, post “test B only”. As `sec_user_b` — visible; as `sec_user_ac` — **not** visible.
+6. **Follow-up — default public:** as `sec_user_ab`, add follow-up with public checked (default). As `sec_user_ac`, follow-up row **must** appear on Follow-up tab.
+7. **Follow-up — restricted:** uncheck public, select `sec-group-b` only, submit. As `sec_user_b` — visible; as `sec_user_ac` — **not** visible.
+
 Backfill existing users on a server snapshot:
 
 ```bash

--- a/docs/security-groups.md
+++ b/docs/security-groups.md
@@ -8,7 +8,7 @@ YSE uses Django **collaboration groups** (`auth.Group`) on photometry, spectra, 
 - **Every user** is a member of the `Public` collaboration group (signal on user create + `ensure_users_in_public_group` for backfill).
 - **New transient comments**: private by default (`Log.is_public=False` with `Log.groups` set to shared collaboration groups). Opt-in `is_public=True` for all collaborators who can open the transient.
 - **Legacy comments** (before migration `0005_log_visibility`): `is_public=True`, no groups — unchanged visibility.
-- **Follow-up requests** (`TransientFollowup`): default **public** (`is_public=True`). Restrict with `is_public=False` and optional `groups` M2M; `requested_by` is set on create.
+- **Follow-up requests** (`TransientFollowup`): audience is set via collaboration groups at create time (`is_public=False` on new rows). Legacy rows with `is_public=True` and no groups remain visible to Public group members who can also see the linked observing resource. Restricted follow-ups require group membership **and** visibility of the linked classical/ToO/queued resource.
 
 ## Code
 
@@ -56,8 +56,8 @@ Tests: `YSE_App.tests.test_tns_import_groups`.
 
 Comments (Summary tab) and follow-up requests expose **Who can see this?** controls at submit time:
 
-- **Comments:** default private to collaboration groups you share on this transient; opt-in checkbox “Visible to all YSE users who can open this transient”. When you belong to multiple groups, checkboxes list which groups may read the comment.
-- **Follow-ups:** default public (checkbox checked); uncheck to restrict to selected collaboration groups.
+- **Comments:** default private to collaboration groups you share on this transient (group checkboxes pre-selected); opt-in checkbox “Visible to all YSE users who can open this transient”. Uncheck public and all groups to keep a comment visible only to you.
+- **Follow-ups:** select collaboration groups that can see the linked observing resource (default: all eligible groups checked). Check **Public** to share with everyone in the Public collaboration group — only enabled when the observing resource is itself public (no group restrictions). At least one eligible group is required. Creator-only requests (no groups) are allowed only for creator-only observing resources (not yet in production).
 
 Automated tests: `YSE_App.tests.test_audience_ui_v1`.
 
@@ -65,11 +65,37 @@ Automated tests: `YSE_App.tests.test_audience_ui_v1`.
 
 1. Seed matrix: `python3 manage.py seed_security_test_matrix`
 2. As `sec_user_ab` / `sec-test-pass`, open `/transient_detail/secvis-matrix/`
-3. **Comment — default private:** post “test private AB” with no audience checkbox. Log in as `sec_user_d` — comment must **not** appear (no shared group). Log in as `sec_user_ab` — comment **must** appear. Log in as `sec_user_ac` — **may** appear (shares group A with the audience).
-4. **Comment — public:** as `sec_user_ab`, check “Visible to all YSE users…”, post “test public”. As `sec_user_ac`, comment **must** appear.
-5. **Comment — group B only:** as `sec_user_ab`, uncheck public, select only `sec-group-b`, post “test B only”. As `sec_user_b` — visible; as `sec_user_ac` — **not** visible.
-6. **Follow-up — default public:** as `sec_user_ab`, add follow-up with public checked (default). As `sec_user_ac`, follow-up row **must** appear on Follow-up tab.
-7. **Follow-up — restricted:** uncheck public, select `sec-group-b` only, submit. As `sec_user_b` — visible; as `sec_user_ac` — **not** visible.
+3. **Comment — default private:** as `sec_user_ab`, leave public unchecked and keep default group checkboxes selected, post “test private AB”. Log in as `sec_user_d` — comment must **not** appear. Log in as `sec_user_ab` — comment **must** appear. Log in as `sec_user_ac` — **may** appear (shares group A with the audience).
+4. **Comment — creator only:** as `sec_user_b`, uncheck public and uncheck `sec-group-b`, post “test creator only”. As `sec_user_b` — visible; as `sec_user_ab` — **not** visible.
+5. **Comment — public:** as `sec_user_ab`, check “Visible to all YSE users…”, post “test public”. As `sec_user_ac`, comment **must** appear.
+6. **Comment — group B only:** as `sec_user_ab`, uncheck public, select only `sec-group-b`, post “test B only”. As `sec_user_b` — visible; as `sec_user_ac` — **not** visible.
+7. **Follow-up — default groups:** as `sec_user_ab`, add follow-up on `SecVis-Cls-mag0-public` with default eligible groups checked. As `sec_user_ac`, follow-up row **must** appear.
+8. **Follow-up — Public group:** on `SecVis-Cls-mag0-public`, check only **Public**, submit. As any user in the Public group with transient access — visible. On `SecVis-Cls-mag2-grpB`, **Public** must be greyed out and unchecked.
+9. **Follow-up — restricted:** select `SecVis-Cls-mag2-grpB`, keep only `sec-group-b` checked, submit. As `sec_user_b` — visible; as `sec_user_ac` — **not** visible.
+10. **Follow-up — no groups:** select `SecVis-Cls-mag2-grpB`, uncheck all groups, submit — form **must** reject with a validation error (red message above Submit).
+11. **Follow-up — submit UX:** after a validation error, fix the selection and submit again without hard refresh; follow-up list should reload.
+12. **Follow-up — `/followup/` page:** as `sec_user_ab`, `SecVis-Cls-mag4-grpD` section must **not** appear; as `sec_user_d`, `SecVis-Cls-mag2-grpB` must **not** appear.
+
+#### Observing resources (follow-up requests)
+
+`seed_security_test_matrix` also creates **24 observing resources** (8 classical + 8 ToO + 8 queued) on the matrix transient, using the same mag/group labeling as photometry:
+
+| Mag | Groups | Telescope suffix example |
+|-----|--------|--------------------------|
+| 0 | public | `SecVis-Cls-mag0-public` |
+| 1 | A | `SecVis-Too-mag1-grpA` |
+| 2 | B | `SecVis-Que-mag2-grpB` |
+| … | … | … |
+
+Each test user sees the same mag numbers in resource dropdowns as on the light curve (e.g. `sec_user_b` → mags `0, 2, 5, 7`).
+
+1. Re-seed: `docker exec ysepz_web_container python3 manage.py seed_security_test_matrix`
+2. Open `/transient_detail/secvis-matrix/` → **Follow-up** tab → **Add Transient Follow-up**
+3. As `sec_user_b`, Classical/ToO/Queued dropdowns should list `mag0`, `mag2`, `mag5`, `mag7` resources only — not `mag1-grpA`.
+4. Submit a follow-up using `SecVis-Cls-mag2-grpB` and verify audience controls separately (steps 7–10 above).
+5. **Observing calendar:** after re-seed, open `/observing_calendar/` as `sec_user_ab` — only classical `SecVis-Cls-*` nights for resources you may use (mags `0, 1, 2, 5, 6, 7`); `mag3-grpC` and `mag4-grpD` must **not** appear. As `sec_user_d`, only `mag0` and `mag4` appear.
+
+Automated tests: `YSE_App.tests.test_security_matrix_resources`.
 
 Backfill existing users on a server snapshot:
 
@@ -97,3 +123,16 @@ Plot HTML cache keys use `group_access_plot_cache_token()` — a hash of sorted 
 
 - Per-group Slack ([#100](https://github.com/Young-Supernova-Experiment/YSE_PZ/issues/100))
 - DRF hardening (`TransientViewSet`, export headers, notifications)
+- `creator_only` observing resources (extension point exists; no production rows yet)
+
+### v1 audience UI — stage status (2026-06)
+
+| Area | Status |
+|------|--------|
+| Comment create-time audience (private default, public opt-in, creator-only) | **done** |
+| Follow-up create-time audience (group checkboxes, Public for public resources) | **done** |
+| Follow-up visibility filter (groups + linked resource; `/followup/` page) | **done** |
+| Observing calendar group filter | **done** |
+| Deferred follow-up form submit (validation + AJAX in early script) | **done** |
+| Security matrix seed + `ClassicalObservingDate` for calendar | **done** |
+| Automated tests (`test_audience_ui_v1`, `test_security_matrix_resources`, `test_group_visibility`) | **done** |


### PR DESCRIPTION
## Summary

- **Comments:** “Who can see this?” on the Summary tab — default private to shared collaboration groups; opt-in “Visible to all YSE users who can open this transient”; creator-only when all groups unchecked.
- **Follow-ups:** group checkboxes on the follow-up form (including **Public** for public observing resources); at least one eligible group required; groups grey out when incompatible with the selected resource.
- **Visibility:** follow-up read access requires group membership (or creator-only / legacy-public rules) **and** visibility of the linked classical/ToO/queued resource; `/followup/` hides telescope sections with no visible rows.
- **Observing calendar:** filtered to authorized classical resources per user.
- **Deferred form UX:** validation and AJAX submit in the early script block with inline red errors (no hard refresh needed after a validation failure).
- **Tests & docs:** `test_audience_ui_v1`, `test_security_matrix_resources`, security matrix seed with `ClassicalObservingDate`; manual checklist in `docs/security-groups.md`.

Builds on group-access phase 4 ([#115](https://github.com/Young-Supernova-Experiment/YSE_PZ/pull/115)). Part of [#102](https://github.com/Young-Supernova-Experiment/YSE_PZ/issues/102).

## Test plan

- [x] `docker exec ysepz_web_container python3 manage.py test YSE_App.tests.test_audience_ui_v1 YSE_App.tests.test_security_matrix_resources YSE_App.tests.test_group_visibility YSE_App.tests.test_security_matrix --keepdb`
- [ ] `python3 manage.py seed_security_test_matrix` then manual matrix in `docs/security-groups.md`
- [ ] As `sec_user_ab`: empty groups → red validation error; valid submit → row appears without hard refresh
- [ ] As `sec_user_ab`: `/observing_calendar/` shows 6 SecVis nights (not mag3/mag4); `/followup/` hides grpD sections

## After merge

No new backfill beyond phase 4 (`ensure_users_in_public_group`, `mark_tns_imports_public`).