### PR TITLE
Phase 5 DRF/export/notifications + creator_only resources

### DIFF
--- a/YSE_App/admin.py
+++ b/YSE_App/admin.py
@@ -34,9 +34,17 @@ admin.site.register(OnCallDate)
 admin.site.register(YSEOnCallDate)
 admin.site.register(Telescope)
 admin.site.register(Instrument)
-admin.site.register(ToOResource)
-admin.site.register(ClassicalResource)
-admin.site.register(QueuedResource)
+
+
+class ObservingResourceAdmin(admin.ModelAdmin):
+	list_display = ("__str__", "creator_only", "begin_date_valid", "end_date_valid")
+	list_filter = ("creator_only",)
+	filter_horizontal = ("groups",)
+
+
+admin.site.register(ToOResource, ObservingResourceAdmin)
+admin.site.register(ClassicalResource, ObservingResourceAdmin)
+admin.site.register(QueuedResource, ObservingResourceAdmin)
 admin.site.register(ClassicalObservingDate)
 admin.site.register(InstrumentConfig)
 admin.site.register(ConfigElement)

--- a/YSE_App/api_views.py
+++ b/YSE_App/api_views.py
@@ -10,6 +10,7 @@ from rest_framework.reverse import reverse
 from .models import *
 from .serializers import *
 from .data import PhotometryService, SpectraService, ObservingResourceService
+from YSE_App.services.visibility import filter_transients_by_user_access
 
 from django_filters.rest_framework import DjangoFilterBackend,filters
 import django_filters
@@ -343,6 +344,13 @@ class ProfileViewSet(custom_viewsets.ListCreateRetrieveUpdateViewSet):
     serializer_class = ProfileSerializer
     permission_classes = (permissions.IsAuthenticated,)
 
+    def get_queryset(self):
+        qs = Profile.objects.all()
+        user = self.request.user
+        if user.is_staff or user.is_superuser:
+            return qs
+        return qs.filter(user=user)
+
 ### `UserQuery` ViewSets ###
 class UserQueryViewSet(custom_viewsets.ListCreateRetrieveUpdateViewSet):
     queryset = UserQuery.objects.all()
@@ -465,6 +473,10 @@ class TransientViewSet(custom_viewsets.ListCreateRetrieveUpdateViewSet):
     filter_class = TransientFilter
     #filter_fields = ('status','created_date','modified_date','mw_ebv','status__name')
 
+    def get_queryset(self):
+        qs = Transient.objects.all()
+        return filter_transients_by_user_access(self.request.user, qs)
+
 class AlternateTransientNamesViewSet(custom_viewsets.ListCreateRetrieveUpdateViewSet):
     queryset = AlternateTransientNames.objects.all()
     serializer_class = AlternateTransientNamesSerializer
@@ -476,11 +488,25 @@ class UserViewSet(viewsets.ReadOnlyModelViewSet):
     serializer_class = UserSerializer
     permission_classes = (permissions.IsAuthenticated,)
 
+    def get_queryset(self):
+        qs = User.objects.all()
+        user = self.request.user
+        if user.is_staff or user.is_superuser:
+            return qs
+        return qs.filter(pk=user.pk)
+
 ### `Group` ViewSets ###
 class GroupViewSet(viewsets.ReadOnlyModelViewSet):
     queryset = Group.objects.all()
     serializer_class = GroupSerializer
     permission_classes = (permissions.IsAuthenticated,)
+
+    def get_queryset(self):
+        qs = Group.objects.all()
+        user = self.request.user
+        if user.is_staff or user.is_superuser:
+            return qs
+        return qs.filter(pk__in=user.groups.values_list("pk", flat=True))
 
 ### `Tag` ViewSets ###
 class TransientTagViewSet(custom_viewsets.ListCreateRetrieveUpdateViewSet):

--- a/YSE_App/forms.py
+++ b/YSE_App/forms.py
@@ -218,7 +218,9 @@ class ClassicalResourceForm(ModelForm):
         model = ClassicalResource
         fields = [
             'telescope',
-            'principal_investigator']
+            'principal_investigator',
+            'creator_only',
+        ]
 
 class ToOResourceForm(ModelForm):
 
@@ -237,7 +239,9 @@ class ToOResourceForm(ModelForm):
             'awarded_too_hours',
             'used_too_hours',
             'awarded_too_triggers',
-            'used_too_triggers']
+            'used_too_triggers',
+            'creator_only',
+        ]
 
 class SurveyFieldForm(ModelForm):
 

--- a/YSE_App/migrations/0007_resource_creator_only.py
+++ b/YSE_App/migrations/0007_resource_creator_only.py
@@ -1,0 +1,26 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("YSE_App", "0006_followup_visibility"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="classicalresource",
+            name="creator_only",
+            field=models.BooleanField(default=False),
+        ),
+        migrations.AddField(
+            model_name="queuedresource",
+            name="creator_only",
+            field=models.BooleanField(default=False),
+        ),
+        migrations.AddField(
+            model_name="tooresource",
+            name="creator_only",
+            field=models.BooleanField(default=False),
+        ),
+    ]

--- a/YSE_App/models/telescope_resource_models.py
+++ b/YSE_App/models/telescope_resource_models.py
@@ -29,6 +29,8 @@ class TelescopeResource(BaseModel):
 
 	# Optional
 	description = models.TextField(null=True, blank=True)
+	# When True, follow-ups may use empty audience (requester-only); see audience.resource_is_creator_only
+	creator_only = models.BooleanField(default=False)
 
 
 class ToOResource(TelescopeResource):

--- a/YSE_App/services/audience.py
+++ b/YSE_App/services/audience.py
@@ -106,8 +106,8 @@ def resource_is_creator_only(resource) -> bool:
     """
     True when the observing resource is private to the requester only.
 
-    No production resources use this yet; set ``creator_only`` on a resource row
-    when that workflow is introduced.
+    Set ``creator_only`` on ClassicalResource / ToOResource / QueuedResource rows
+    (BooleanField, default False) when that workflow is needed.
     """
     if resource is None:
         return False

--- a/YSE_App/services/notifications.py
+++ b/YSE_App/services/notifications.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import re
-from typing import List
+from typing import List, Optional
 
 import numpy as np
 from django.conf import settings
@@ -11,6 +11,7 @@ from django.contrib.auth.models import User
 
 from YSE_App.common import alert
 from YSE_App.models import Log
+from YSE_App.services.visibility import log_visible_to_user
 
 
 def _comment_base_url() -> str:
@@ -21,24 +22,32 @@ def _comment_base_url() -> str:
     return "https://ziggy.ucolick.org/yse/"
 
 
-def collect_mention_emails(comment_text: str) -> List[str]:
+def collect_mention_emails(
+    comment_text: str, log: Optional[Log] = None
+) -> List[str]:
+    """Return emails for @mentions / @channel that may view ``log`` when provided."""
     emaillist = []
     if "@channel" in comment_text:
-        for user in User.objects.all():
-            if user.email:
-                emaillist.append(user.email)
+        candidates = User.objects.exclude(email="").exclude(email__isnull=True)
+        for user in candidates:
+            if log is not None and not log_visible_to_user(user, log):
+                continue
+            emaillist.append(user.email)
     else:
         for username in re.compile(r"@(\w+)").findall(comment_text):
-            usermatch = User.objects.filter(username=username)
-            if len(usermatch) and usermatch[0].email:
-                emaillist.append(usermatch[0].email)
+            usermatch = User.objects.filter(username=username).first()
+            if not usermatch or not usermatch.email:
+                continue
+            if log is not None and not log_visible_to_user(usermatch, log):
+                continue
+            emaillist.append(usermatch.email)
     return list(np.unique(emaillist))
 
 
 def notify_email_mentions(log: Log) -> None:
     if not log.transient_id or not log.comment:
         return
-    emaillist = collect_mention_emails(log.comment)
+    emaillist = collect_mention_emails(log.comment, log=log)
     if not emaillist:
         return
     transient_name = log.transient.name

--- a/YSE_App/services/visibility.py
+++ b/YSE_App/services/visibility.py
@@ -167,6 +167,35 @@ def filter_transients_by_user_access(
     return [t for t in transients if user_can_view_transient(user, t.id)]
 
 
+# Transient detail shell allows broad metadata; export zip headers must stay narrow.
+EXPORT_TRANSIENT_HEADER_ALLOWLIST = frozenset(
+    {
+        "name",
+        "ra",
+        "dec",
+        "disc_date",
+        "slug",
+        "status",
+        "obs_group",
+        "mw_ebv",
+        "redshift",
+        "redshift_err",
+        "redshift_source",
+        "non_detect_limit",
+        "non_detect_instrument",
+        "non_detect_band",
+        "non_detect_date",
+        "TNS_name",
+        "TNS_spec_class",
+    }
+)
+
+
+def redact_transient_export_header_fields(fields: dict) -> dict:
+    """Keep public-facing metadata keys only in bulk photometry export headers."""
+    return {k: v for k, v in fields.items() if k in EXPORT_TRANSIENT_HEADER_ALLOWLIST}
+
+
 def _user_in_public_group(user: User) -> bool:
     return PUBLIC_COLLABORATION_GROUP_NAME in user_group_names(user)
 

--- a/YSE_App/tests/fixtures_security_matrix.py
+++ b/YSE_App/tests/fixtures_security_matrix.py
@@ -288,6 +288,20 @@ def create_secvis_matrix_resources(admin: User) -> None:
                 groups=groups,
                 principal_investigator=pi,
             )
+    # Dedicated creator-only classical resource (empty audience follow-ups allowed).
+    creator_resource = _attach_labeled_resource(
+        admin,
+        mag=99,
+        group_keys=["a"],
+        band_suffix="creatorOnly",
+        kind_code="Cls",
+        kind_label="classical",
+        resource_model=ClassicalResource,
+        groups=groups,
+        principal_investigator=pi,
+    )
+    creator_resource.creator_only = True
+    creator_resource.save(update_fields=["creator_only"])
 
 
 def create_secvis_matrix_transient(admin: User) -> Transient:

--- a/YSE_App/tests/test_phase5_hardening.py
+++ b/YSE_App/tests/test_phase5_hardening.py
@@ -1,0 +1,180 @@
+"""Phase 5: DRF scoping, export header redaction, notification audience checks."""
+
+from __future__ import annotations
+
+from datetime import timedelta
+
+from django.contrib.auth.models import Group, User
+from django.test import Client, TestCase
+from django.urls import reverse
+from django.utils import timezone
+from rest_framework.test import APIClient
+
+from YSE_App.models import FollowupStatus, Log, TransientFollowup
+from YSE_App.services.notifications import collect_mention_emails
+from YSE_App.services.visibility import (
+    EXPORT_TRANSIENT_HEADER_ALLOWLIST,
+    redact_transient_export_header_fields,
+)
+from YSE_App.tests.fixtures_minimal import create_minimal_transient
+from YSE_App.tests.fixtures_security_matrix import (
+    TRANSIENT_NAME,
+    seed_security_test_matrix,
+)
+
+
+class Phase5DRFHardeningTests(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.transient, cls.users = seed_security_test_matrix()
+        cls.user_b = cls.users["sec_user_b"]
+        cls.staff = User.objects.create_user(
+            username="sec_staff", password="sec-test-pass", is_staff=True
+        )
+
+    def test_user_viewset_non_staff_sees_self_only(self):
+        client = APIClient()
+        client.force_authenticate(user=self.user_b)
+        response = client.get("/api/users/")
+        self.assertEqual(response.status_code, 200)
+        results = response.data["results"] if "results" in response.data else response.data
+        usernames = {row["username"] for row in results}
+        self.assertEqual(usernames, {"sec_user_b"})
+
+    def test_group_viewset_non_staff_sees_own_groups_only(self):
+        client = APIClient()
+        client.force_authenticate(user=self.user_b)
+        response = client.get("/api/groups/")
+        self.assertEqual(response.status_code, 200)
+        results = response.data["results"] if "results" in response.data else response.data
+        names = {row["name"] for row in results}
+        self.assertTrue(
+            names.issubset(set(self.user_b.groups.values_list("name", flat=True)))
+        )
+        self.assertNotIn("sec-group-c", names)
+        self.assertNotIn("sec-group-d", names)
+
+    def test_transient_viewset_respects_access_filter(self):
+        client = APIClient()
+        client.force_authenticate(user=self.user_b)
+        response = client.get("/api/transients/")
+        self.assertEqual(response.status_code, 200)
+
+
+class Phase5ExportRedactionTests(TestCase):
+    def test_redact_drops_non_allowlisted_keys(self):
+        fields = {
+            "name": "2026abc",
+            "ra": 1.0,
+            "dec": 2.0,
+            "status": "New",
+            "created_by": "admin",
+            "some_private_note": "secret",
+        }
+        redacted = redact_transient_export_header_fields(fields)
+        self.assertEqual(set(redacted.keys()), {"name", "ra", "dec", "status"})
+        self.assertNotIn("created_by", redacted)
+        self.assertNotIn("some_private_note", redacted)
+        self.assertTrue(set(redacted.keys()).issubset(EXPORT_TRANSIENT_HEADER_ALLOWLIST))
+
+
+class Phase5NotificationAudienceTests(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.admin = User.objects.create_user(username="notif_admin", password="x")
+        cls.group_a = Group.objects.create(name="notif-group-a")
+        cls.group_b = Group.objects.create(name="notif-group-b")
+        cls.author = User.objects.create_user(
+            username="notif_author", password="x", email="author@example.com"
+        )
+        cls.author.groups.add(cls.group_a)
+        cls.insider = User.objects.create_user(
+            username="notif_insider", password="x", email="insider@example.com"
+        )
+        cls.insider.groups.add(cls.group_a)
+        cls.outsider = User.objects.create_user(
+            username="notif_outsider", password="x", email="outsider@example.com"
+        )
+        cls.outsider.groups.add(cls.group_b)
+        cls.transient = create_minimal_transient(cls.admin, name="notif-transient")
+
+    def _private_log(self, comment: str) -> Log:
+        log = Log.objects.create(
+            transient=self.transient,
+            comment=comment,
+            is_public=False,
+            created_by=self.author,
+            modified_by=self.author,
+        )
+        log.groups.set([self.group_a])
+        return log
+
+    def test_channel_mention_skips_users_who_cannot_view_log(self):
+        log = self._private_log("@channel please look")
+        emails = collect_mention_emails(log.comment, log=log)
+        self.assertIn("insider@example.com", emails)
+        self.assertIn("author@example.com", emails)
+        self.assertNotIn("outsider@example.com", emails)
+
+    def test_user_mention_skips_invisible_recipient(self):
+        log = self._private_log("@notif_outsider secret")
+        emails = collect_mention_emails(log.comment, log=log)
+        self.assertEqual(list(emails), [])
+
+    def test_user_mention_allows_visible_recipient(self):
+        log = self._private_log("@notif_insider hello")
+        emails = collect_mention_emails(log.comment, log=log)
+        self.assertEqual(list(emails), ["insider@example.com"])
+
+
+class Phase5CreatorOnlyResourceTests(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.transient, cls.users = seed_security_test_matrix()
+        cls.user_ab = cls.users["sec_user_ab"]
+        cls.status, _ = FollowupStatus.objects.get_or_create(
+            name="sec-phase5-requested",
+            defaults={
+                "created_by": cls.user_ab,
+                "modified_by": cls.user_ab,
+            },
+        )
+
+    def test_seed_creates_creator_only_classical_resource(self):
+        from YSE_App.models import ClassicalResource
+        from YSE_App.services.audience import resource_is_creator_only
+
+        resource = ClassicalResource.objects.get(
+            telescope__name="SecVis-Cls-mag99-creatorOnly"
+        )
+        self.assertTrue(resource.creator_only)
+        self.assertTrue(resource_is_creator_only(resource))
+
+    def test_empty_audience_allowed_on_creator_only_resource(self):
+        from YSE_App.models import ClassicalResource
+
+        resource = ClassicalResource.objects.get(
+            telescope__name="SecVis-Cls-mag99-creatorOnly"
+        )
+        client = Client()
+        client.force_login(self.user_ab)
+        now = timezone.now()
+        response = client.post(
+            reverse("add_transient_followup"),
+            {
+                "status": self.status.pk,
+                "transient": self.transient.pk,
+                "valid_start": now.isoformat(),
+                "valid_stop": (now + timedelta(days=2)).isoformat(),
+                "classical_resource": resource.pk,
+                "audience_groups": [],
+            },
+            HTTP_X_REQUESTED_WITH="XMLHttpRequest",
+        )
+        self.assertEqual(response.status_code, 200, response.content)
+        followup = TransientFollowup.objects.filter(
+            transient=self.transient,
+            classical_resource=resource,
+            requested_by=self.user_ab,
+        ).latest("id")
+        self.assertFalse(followup.groups.exists())

--- a/YSE_App/views.py
+++ b/YSE_App/views.py
@@ -1905,7 +1905,10 @@ def download_bulk_photometry(request, query_title):
         transients = filter_transients_by_user_access(user, transients)
 
     elif getattr(yse_python_queries,query_title):
+        from YSE_App.services.visibility import filter_transients_by_user_access
+
         transients = getattr(yse_python_queries,query_title)()
+        transients = filter_transients_by_user_access(user, transients)
 
     s = BytesIO()
     archive = zipfile.ZipFile(s, 'w', zipfile.ZIP_DEFLATED)
@@ -1915,9 +1918,13 @@ def download_bulk_photometry(request, query_title):
 
         data = {transient.name:{'transient':{},'host':{},'photometry':{},'spectra':{}}}
         data[transient.name]['transient'] = json.loads(serializers.serialize("json", Transient.objects.filter(name=transient.name), use_natural_foreign_keys=True))
-        for k in data[transient.name]['transient'][0]['fields'].keys():
-            if k not in ['created_by','modified_by','candidate_hosts']:
-                content += "# %s: %s\n"%(k.upper(),data[transient.name]['transient'][0]['fields'][k])
+        from YSE_App.services.visibility import redact_transient_export_header_fields
+
+        header_fields = redact_transient_export_header_fields(
+            data[transient.name]['transient'][0]['fields']
+        )
+        for k in header_fields.keys():
+            content += "# %s: %s\n"%(k.upper(),header_fields[k])
 
         content += "\n"
         content += "MJD,FLT,FLUXCAL,FLUXCALERR,MAG,MAGERR,MAGSYS,TELESCOPE,INSTRUMENT\n"

--- a/docs/security-groups.md
+++ b/docs/security-groups.md
@@ -121,9 +121,13 @@ Plot HTML cache keys use `group_access_plot_cache_token()` — a hash of sorted 
 
 ## Remaining ([#102](https://github.com/Young-Supernova-Experiment/YSE_PZ/issues/102))
 
-- Per-group Slack ([#100](https://github.com/Young-Supernova-Experiment/YSE_PZ/issues/100))
-- DRF hardening (`TransientViewSet`, export headers, notifications)
-- `creator_only` observing resources (extension point exists; no production rows yet)
+**Ship in progress** on `security/phase-5-hardening` → `experimental` → `develop` → `master`:
+
+- Phase 5 DRF hardening (`TransientViewSet`, User/Profile/Group viewsets)
+- Export header redaction + notification audience checks
+- `creator_only` BooleanField on Classical/ToO/Queued resources (admin + forms)
+
+**Deferred (not #102):** per-group Slack [#100](https://github.com/Young-Supernova-Experiment/YSE_PZ/issues/100), Slack docs [#101](https://github.com/Young-Supernova-Experiment/YSE_PZ/issues/101).
 
 ### v1 audience UI — stage status (2026-06)
 


### PR DESCRIPTION
## Summary
- Add `creator_only` BooleanField on Classical/ToO/Queued resources (migration `0007`), admin, forms
- Scope `TransientViewSet`, `UserViewSet`, `ProfileViewSet`, `GroupViewSet` for non-staff
- Redact bulk photometry export headers to public metadata allowlist; filter python-query export path
- Gate `@channel` / `@user` mention emails with `log_visible_to_user`
- Tests: `test_phase5_hardening.py`; security matrix seeds a creator-only classical resource

Fixes #102

## Test plan
- [ ] `manage.py test YSE_App.tests.test_phase5_hardening YSE_App.tests.test_audience_ui_v1 YSE_App.tests.test_group_visibility YSE_App.tests.test_security_matrix --keepdb`
- [ ] Migrate `0007_resource_creator_only`
- [ ] Confirm Slack #100/#101 remain open (out of scope)


Made with [Cursor](https://cursor.com)