### PR TITLE
Fix creator-only follow-up UI + staff /api/users/

### DIFF
--- a/YSE_App/serializers/user_serializers.py
+++ b/YSE_App/serializers/user_serializers.py
@@ -1,7 +1,28 @@
 from rest_framework import serializers
 from django.contrib.auth.models import User
 
-class UserSerializer(serializers.HyperlinkedModelSerializer):
+
+class UserSerializer(serializers.ModelSerializer):
+	"""Read-oriented user payload for /api/users/.
+
+	Avoid HyperlinkedModelSerializer ``fields = "__all__"``: that tries to
+	reverse ``permission-detail`` for ``user_permissions`` and 500s for staff.
+	"""
+
+	url = serializers.HyperlinkedIdentityField(view_name="user-detail")
+	groups = serializers.SlugRelatedField(many=True, read_only=True, slug_field="name")
+
 	class Meta:
 		model = User
-		fields = "__all__"
+		fields = (
+			"id",
+			"url",
+			"username",
+			"email",
+			"first_name",
+			"last_name",
+			"is_staff",
+			"is_superuser",
+			"is_active",
+			"groups",
+		)

--- a/YSE_App/services/audience.py
+++ b/YSE_App/services/audience.py
@@ -157,6 +157,7 @@ def build_followup_resource_audience_map(form) -> Dict[str, Dict[str, Any]]:
             resource_map[f"{field_name}:{resource.pk}"] = {
                 "is_public": resource_is_public(resource),
                 "group_ids": list(resource.groups.values_list("pk", flat=True)),
+                "creator_only": bool(getattr(resource, "creator_only", False)),
             }
     return resource_map
 

--- a/YSE_App/templates/YSE_App/form_snippets/transient_followup_form.html
+++ b/YSE_App/templates/YSE_App/form_snippets/transient_followup_form.html
@@ -103,6 +103,8 @@
 									Select collaboration groups that can see the selected observing resource
 									(default: all eligible groups checked). Check <strong>Public</strong> to share
 									with everyone in the Public group (only available for public observing resources).
+									For <strong>creator-only</strong> observing resources, you may leave all groups
+									unchecked so only you (the requester) can see the follow-up.
 								</p>
 								{% for choice in form.followup_audience_choices %}
 								<div class="checkbox yse-followup-audience-choice" data-group-id="{{ choice.group.pk }}">

--- a/YSE_App/templates/YSE_App/transient_detail.html
+++ b/YSE_App/templates/YSE_App/transient_detail.html
@@ -276,14 +276,14 @@
                 activeField = yseUpdateActiveFollowupResourceField($form);
             }
             if (!activeField) {
-                return { is_public: false, group_ids: [] };
+                return { is_public: false, group_ids: [], creator_only: false };
             }
             var resourcePk = $form.find('select[name=' + activeField + ']').val();
             if (!resourcePk) {
-                return { is_public: false, group_ids: [] };
+                return { is_public: false, group_ids: [], creator_only: false };
             }
             var key = activeField + ':' + resourcePk;
-            return map[key] || { is_public: false, group_ids: [] };
+            return map[key] || { is_public: false, group_ids: [], creator_only: false };
         }
 
         function yseGroupIdEligible(groupId, meta) {
@@ -380,10 +380,17 @@
                 );
                 return false;
             }
+            var resourceMeta = yseSelectedFollowupResourceMeta($form);
+            var creatorOnly = resourceMeta.creator_only === true
+                || resourceMeta.creator_only === 'true';
             var checkedEligible = $form.find(
                 '.yse-followup-audience-group:checked:not(:disabled)'
             ).length;
-            if ($form.find('.yse-followup-audience-group').length && checkedEligible < 1) {
+            if (
+                !creatorOnly
+                && $form.find('.yse-followup-audience-group').length
+                && checkedEligible < 1
+            ) {
                 yseFollowupShowSubmitError(
                     'Select at least one collaboration group for this follow-up.'
                 );

--- a/YSE_App/tests/test_phase5_hardening.py
+++ b/YSE_App/tests/test_phase5_hardening.py
@@ -4,13 +4,16 @@ from __future__ import annotations
 
 from datetime import timedelta
 
-from django.contrib.auth.models import Group, User
+from django.contrib.auth.models import Group, Permission, User
+from django.contrib.contenttypes.models import ContentType
 from django.test import Client, TestCase
 from django.urls import reverse
 from django.utils import timezone
 from rest_framework.test import APIClient
 
+from YSE_App.forms import TransientFollowupForm
 from YSE_App.models import FollowupStatus, Log, TransientFollowup
+from YSE_App.services.audience import build_followup_resource_audience_map
 from YSE_App.services.notifications import collect_mention_emails
 from YSE_App.services.visibility import (
     EXPORT_TRANSIENT_HEADER_ALLOWLIST,
@@ -41,6 +44,27 @@ class Phase5DRFHardeningTests(TestCase):
         usernames = {row["username"] for row in results}
         self.assertEqual(usernames, {"sec_user_b"})
 
+    def test_user_viewset_staff_list_ok(self):
+        """Staff list must not 500 on hyperlinked user_permissions."""
+        from YSE_App.models import Transient
+
+        ct = ContentType.objects.get_for_model(Transient)
+        perm = Permission.objects.filter(content_type=ct).first()
+        self.assertIsNotNone(perm)
+        self.staff.user_permissions.add(perm)
+
+        client = APIClient()
+        client.force_authenticate(user=self.staff)
+        response = client.get("/api/users/")
+        self.assertEqual(response.status_code, 200, response.content)
+        results = response.data["results"] if "results" in response.data else response.data
+        usernames = {row["username"] for row in results}
+        self.assertIn("sec_staff", usernames)
+        self.assertIn("sec_user_b", usernames)
+        for row in results:
+            self.assertNotIn("user_permissions", row)
+            self.assertNotIn("password", row)
+
     def test_group_viewset_non_staff_sees_own_groups_only(self):
         client = APIClient()
         client.force_authenticate(user=self.user_b)
@@ -59,6 +83,25 @@ class Phase5DRFHardeningTests(TestCase):
         client.force_authenticate(user=self.user_b)
         response = client.get("/api/transients/")
         self.assertEqual(response.status_code, 200)
+
+    def test_followup_resource_audience_map_includes_creator_only(self):
+        from YSE_App.models import ClassicalResource
+
+        user_ab = self.users["sec_user_ab"]
+        form = TransientFollowupForm(user=user_ab)
+        resource_map = build_followup_resource_audience_map(form)
+        resource = ClassicalResource.objects.get(
+            telescope__name="SecVis-Cls-mag99-creatorOnly"
+        )
+        key = f"classical_resource:{resource.pk}"
+        self.assertIn(key, resource_map)
+        self.assertTrue(resource_map[key]["creator_only"])
+        public = ClassicalResource.objects.get(
+            telescope__name="SecVis-Cls-mag0-public"
+        )
+        public_key = f"classical_resource:{public.pk}"
+        self.assertIn(public_key, resource_map)
+        self.assertFalse(resource_map[public_key]["creator_only"])
 
 
 class Phase5ExportRedactionTests(TestCase):


### PR DESCRIPTION
## Summary
- Client follow-up validation skips the “at least one group” check when the selected observing resource is `creator_only` (resource audience map now exposes the flag).
- Narrow `UserSerializer` so staff `GET /api/users/` no longer crashes on missing `permission-detail`.
- Tests for staff user list and creator_only map metadata.

## Test plan
- [ ] As `sec_user_ab`, follow-up on `SecVis-Cls-mag99-creatorOnly` with all groups unchecked → submit succeeds
- [ ] As `admin123`, `http://127.0.0.1:8080/api/users/` returns 200 (not ImproperlyConfigured)
- [ ] Non-creator-only resource with no groups still shows validation error
- [ ] `docker exec ysepz_web_container python3 manage.py test YSE_App.tests.test_phase5_hardening --keepdb -v2`


Made with [Cursor](https://cursor.com)