### PR TITLE
Soft-fail TESS lookup for CI / transient create

### DIFF
--- a/YSE_App/common/tess_obs.py
+++ b/YSE_App/common/tess_obs.py
@@ -1,10 +1,12 @@
 import hashlib
+import logging
 import re
 
 import requests
 from django.core.cache import cache
 
 _TESS_CACHE_TTL = 60 * 60 * 24 * 7  # 7 days
+logger = logging.getLogger(__name__)
 
 
 def _tess_cache_key(ra, dec, discovery_jd):
@@ -13,6 +15,12 @@ def _tess_cache_key(ra, dec, discovery_jd):
 
 
 def tess_obs(ra, dec, discovery_jd):
+	"""Return True if TESS likely observed this sky position near discovery_jd.
+
+	Network / HEASARC failures must not raise: transient post_save (and CI)
+	call this on every create. Soft-fail to False without caching so a later
+	save can retry when the service recovers.
+	"""
 	key = _tess_cache_key(ra, dec, discovery_jd)
 	cached = cache.get(key)
 	if cached is not None:
@@ -35,12 +43,17 @@ def tess_obs(ra, dec, discovery_jd):
 		2460068.5,2460097.5,2460126.5,2460154.5,2460181.5,2460207.5]
 	url = 'https://heasarc.gsfc.nasa.gov/cgi-bin/tess/webtess/'
 	url += 'wtv.py?Entry={ra}%2C{dec}'
-	r = requests.get(url.format(ra=str(ra), dec=str(dec)))
-	if r.status_code!=200:
-		print('status message:',r.text)
-		error = 'ERROR: could not get {url}, status code {code}'
-		raise RuntimeError(error.format(url=url, code=r.status_code))
-		return(None)
+	try:
+		r = requests.get(url.format(ra=str(ra), dec=str(dec)), timeout=15)
+	except requests.RequestException as exc:
+		logger.warning("TESS footprint query failed (%s); skipping tag", exc)
+		return False
+	if r.status_code != 200:
+		logger.warning(
+			"TESS footprint query returned HTTP %s; skipping tag",
+			r.status_code,
+		)
+		return False
 
 	reg = r"observed in camera \w+.\nSector \w+"
 	info = re.findall(reg, r.content.decode())
@@ -57,15 +70,3 @@ def tess_obs(ra, dec, discovery_jd):
 					return True
 	cache.set(key, False, _TESS_CACHE_TTL)
 	return False
-
-# These should be false
-#print("Should be false:")
-#print tess_obs(94.1105250, -21.3756833, 2458481.52282)
-#print tess_obs(202.884383, -12.4804833, 2458526.52282)
-#print tess_obs(308.684333, +60.1933063, 2458526.52282)
-
-# These should be true
-#print "Should be true:"
-#print tess_obs(64.46742, -63.67525, 2458345.52282) # 2018fhw
-#print tess_obs(65.13394, -38.96065, 2458440.52282) # 2018ioa
-#print tess_obs(98.38955, -61.00797, 2458509.52282) # 2019aeg

--- a/YSE_App/tests/test_tess_obs_soft_fail.py
+++ b/YSE_App/tests/test_tess_obs_soft_fail.py
@@ -1,0 +1,27 @@
+"""TESS footprint lookup must not break transient create / CI."""
+
+from unittest.mock import MagicMock, patch
+
+from django.test import SimpleTestCase
+
+from YSE_App.common.tess_obs import tess_obs
+
+
+class TessObsSoftFailTests(SimpleTestCase):
+    @patch("YSE_App.common.tess_obs.cache")
+    @patch("YSE_App.common.tess_obs.requests.get")
+    def test_http_403_returns_false(self, mock_get, mock_cache):
+        mock_cache.get.return_value = None
+        mock_get.return_value = MagicMock(status_code=403, text="forbidden")
+        self.assertFalse(tess_obs(150.0, 2.5, 2459000.5))
+        mock_cache.set.assert_not_called()
+
+    @patch("YSE_App.common.tess_obs.cache")
+    @patch("YSE_App.common.tess_obs.requests.get")
+    def test_request_exception_returns_false(self, mock_get, mock_cache):
+        import requests
+
+        mock_cache.get.return_value = None
+        mock_get.side_effect = requests.Timeout("slow")
+        self.assertFalse(tess_obs(150.0, 2.5, 2459000.5))
+        mock_cache.set.assert_not_called()


### PR DESCRIPTION
## Summary
- `tess_obs` no longer raises on HEASARC HTTP errors or network failures (returns `False`, does not cache the failure).
- Fixes mass CI/local test failures when HEASARC returns 403 during `Transient` post_save.
- Unit tests for 403 and timeout soft-fail.

## Test plan
- [ ] `manage.py test YSE_App.tests.test_tess_obs_soft_fail -v2`
- [ ] CI on #120 / experimental goes green (or at least no TESS RuntimeError cascade)
- [ ] Creating a transient still works when HEASARC is unreachable


Made with [Cursor](https://cursor.com)