### PR TITLE
ci: auto-deploy develop stack after merge

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,35 +1,61 @@
-name: Deploy Experimental Stack
+name: Deploy Stack
 
 on:
   push:
     branches:
       - experimental
+      - develop
   pull_request:
     branches:
       - experimental
+      - develop
     types:
       - closed
 
 jobs:
   deploy:
     if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.pull_request.merged == true)
-    
-    # This is the magic line that tells GitHub to use your Ziggy runner!
+
+    # Self-hosted Ziggy runner
     runs-on: self-hosted
 
     steps:
+      - name: Resolve deploy target
+        id: target
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            BRANCH="${{ github.event.pull_request.base.ref }}"
+          else
+            BRANCH="${{ github.ref_name }}"
+          fi
+          case "$BRANCH" in
+            experimental)
+              echo "dir=/data/yse_pz/YSE_PZ_experimental" >> "$GITHUB_OUTPUT"
+              echo "branch=experimental" >> "$GITHUB_OUTPUT"
+              ;;
+            develop)
+              echo "dir=/data/yse_pz/YSE_PZ_develop" >> "$GITHUB_OUTPUT"
+              echo "branch=develop" >> "$GITHUB_OUTPUT"
+              ;;
+            *)
+              echo "Unsupported deploy branch: $BRANCH" >&2
+              exit 1
+              ;;
+          esac
+          echo "Deploying branch=$BRANCH"
+
       - name: Deploy Application
         run: |
-          cd /data/yse_pz/YSE_PZ_experimental
-          
+          cd "${{ steps.target.outputs.dir }}"
+
           git fetch origin
-          git reset --hard origin/experimental
-          
+          git reset --hard "origin/${{ steps.target.outputs.branch }}"
+
           ./venv/bin/pip install wheel
           ./venv/bin/pip install --no-build-isolation "extinction==0.4.2"
           ./venv/bin/pip install "sncosmo==2.8.0" "urllib3<1.27" "django>=3.2,<4.0"
           ./venv/bin/pip install --use-deprecated=legacy-resolver -r requirements.txt
-          
+
           ./venv/bin/python manage.py migrate --noinput --skip-checks
-          
+
           sudo systemctl restart apache2

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -34,7 +34,7 @@ jobs:
               echo "branch=experimental" >> "$GITHUB_OUTPUT"
               ;;
             develop)
-              echo "dir=/data/yse_pz/YSE_PZ_develop" >> "$GITHUB_OUTPUT"
+              echo "dir=/data/yse_pz/YSE_PZ_test" >> "$GITHUB_OUTPUT"
               echo "branch=develop" >> "$GITHUB_OUTPUT"
               ;;
             *)


### PR DESCRIPTION
## Summary
- Extend `.github/workflows/deploy.yml` so `develop` (push + merged PRs) gets the same full Ziggy deploy as `experimental`
- Target checkout: `/data/yse_pz/YSE_PZ_test` → `origin/develop`
- Keep experimental on `/data/yse_pz/YSE_PZ_experimental`

Fixes #145

## Test plan
- [ ] Merge to `experimental` → existing experimental deploy still succeeds
- [ ] Promote to `develop` → develop deploy runs against `YSE_PZ_test`
- [ ] Confirm Apache restart and migrate `--skip-checks` still used