### PR TITLE
docs: experimental needs /experimental_static/ Apache Alias

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -63,7 +63,8 @@ jobs:
 
           "$PYTHON" manage.py migrate --noinput --skip-checks
 
-          # Apache serves /static/ from STATIC_ROOT; chrome/vendor CSS lands here.
+          # Writes into this stack's STATIC_ROOT. Apache must Alias that URL
+          # (prod: /static/, test: /test_static/, experimental: /experimental_static/).
           "$PYTHON" manage.py collectstatic --noinput
 
           sudo systemctl restart apache2

--- a/docs/ziggy-static-aliases.md
+++ b/docs/ziggy-static-aliases.md
@@ -1,0 +1,49 @@
+# Ziggy Apache static aliases
+
+Each stack has its own `STATIC_ROOT` under `/data/yse_pz/.../YSE_PZ/static/`.
+Deploy runs `collectstatic` into that tree. Browsers only see those files if
+Apache has a matching `Alias` **and** that stack’s `site_settings.ini`
+`STATIC:` matches the Alias URL.
+
+| Stack | App path | Alias (Apache) | `STATIC:` in settings.ini |
+|-------|----------|----------------|---------------------------|
+| production (`yse`) | `/data/yse_pz/YSE_PZ` | `/static/` | `/static/` |
+| test (`yse_test`) | `/data/yse_pz/YSE_PZ_test` | `/test_static/` | `/test_static/` |
+| experimental (`yse_experimental`) | `/data/yse_pz/YSE_PZ_experimental` | `/experimental_static/` | `/experimental_static/` |
+
+## Add experimental static (one-time on Ziggy)
+
+In `yse-experimental.conf` (sites-enabled), next to the other Alias/WSGI lines:
+
+```apache
+Alias /experimental_static/ /data/yse_pz/YSE_PZ_experimental/YSE_PZ/static/
+<Directory /data/yse_pz/YSE_PZ_experimental/YSE_PZ/static>
+    Require all granted
+</Directory>
+```
+
+In `/data/yse_pz/YSE_PZ_experimental/YSE_PZ/settings.ini` (or whatever file
+that install uses for `[site_settings]`):
+
+```ini
+STATIC: /experimental_static/
+```
+
+Then:
+
+```bash
+cd /data/yse_pz/YSE_PZ_experimental
+./venv/bin/python manage.py collectstatic --noinput
+sudo apache2ctl configtest && sudo systemctl reload apache2
+```
+
+Check:
+
+```bash
+curl -sI https://ziggy.ucolick.org/experimental_static/YSE_App/vendor/adminlte-3.2/css/adminlte.min.css
+```
+
+Expect `200`. Hard-refresh `yse_experimental`.
+
+**Do not** point experimental `STATIC:` at `/static/` — that Alias is production
+and will keep serving the old tree (or 404 new vendor paths).


### PR DESCRIPTION
## Summary
- Document that `yse_experimental` has no Apache static Alias (unlike `/static/` and `/test_static/`), so collectstatic into experimental never reaches the browser while `STATIC: /static/` points at production.
- Clarify deploy.yml collectstatic comment for the three stacks.

## Ops (Ziggy, not in this PR)
Add `Alias /experimental_static/ …/YSE_PZ_experimental/YSE_PZ/static/` and set experimental `STATIC: /experimental_static/`. See `docs/ziggy-static-aliases.md`.

## Test plan
- [ ] Apply Alias + STATIC on Ziggy; `curl -sI …/experimental_static/YSE_App/vendor/adminlte-3.2/css/adminlte.min.css` → 200
- [ ] Hard-refresh yse_experimental chrome


Made with [Cursor](https://cursor.com)