### PR TITLE
fix: chrome CI test assertions (checked order, cache-bust query)

### DIFF
--- a/YSE_App/tests/static_asset_utils.py
+++ b/YSE_App/tests/static_asset_utils.py
@@ -45,13 +45,14 @@ def local_static_paths_from_html(html):
 
 
 def static_relpath_from_url(static_url_path):
-    """Map /static/YSE_App/foo.css -> YSE_App/foo.css."""
+    """Map /static/YSE_App/foo.css -> YSE_App/foo.css (strip ?v= cache-bust)."""
+    path = urlparse(static_url_path).path
     prefix = static_url_prefix()
-    if static_url_path.startswith(prefix):
-        return static_url_path[len(prefix) :].lstrip("/")
-    if static_url_path.startswith("/static/"):
-        return static_url_path[len("/static/") :]
-    return static_url_path.lstrip("/")
+    if path.startswith(prefix):
+        return path[len(prefix) :].lstrip("/")
+    if path.startswith("/static/"):
+        return path[len("/static/") :]
+    return path.lstrip("/")
 
 
 def static_asset_available(relative_path):

--- a/YSE_App/tests/test_chrome.py
+++ b/YSE_App/tests/test_chrome.py
@@ -77,12 +77,19 @@ class ChromeSmokeTests(TestCase):
         self.assertIn("sec-group-a", html)
         self.assertIn("sec-group-b", html)
         self.assertNotIn('id="id_audience_groups_%s"' % group_public.pk, html)
-        self.assertNotRegex(html, r'id="id_is_public"[^>]*\bchecked\b')
-        self.assertRegex(
-            html, r'id="id_audience_groups_%s"[^>]*\bchecked\b' % group_a.pk
+        self.assertNotRegex(
+            html,
+            r'<input(?=[^>]*\bid="id_is_public")(?=[^>]*\bchecked\b)[^>]*>',
         )
         self.assertRegex(
-            html, r'id="id_audience_groups_%s"[^>]*\bchecked\b' % group_b.pk
+            html,
+            r'<input(?=[^>]*\bid="id_audience_groups_%s")(?=[^>]*\bchecked\b)[^>]*>'
+            % group_a.pk,
+        )
+        self.assertRegex(
+            html,
+            r'<input(?=[^>]*\bid="id_audience_groups_%s")(?=[^>]*\bchecked\b)[^>]*>'
+            % group_b.pk,
         )
 
     def test_transient_detail_chrome(self):


### PR DESCRIPTION
## Summary
- Audience checkbox assertions allow \`checked\` before or after \`id\` (Django attribute order).
- \`static_relpath_from_url\` strips \`?v=\` so \`yse-theme.css?v=tags-1\` resolves to the real file.

## Test plan
- [ ] \`manage.py test YSE_App.tests.test_chrome.ChromeSmokeTests.test_comment_audience_lists_all_user_groups YSE_App.tests.test_transient_detail_assets.TransientDetailLocalStaticTests --keepdb\`


Made with [Cursor](https://cursor.com)