### PR TITLE
fix: audience checkbox tests use value=pk (not id index)

### DIFF
--- a/YSE_App/tests/test_chrome.py
+++ b/YSE_App/tests/test_chrome.py
@@ -76,19 +76,22 @@ class ChromeSmokeTests(TestCase):
         self.assertEqual(html.count(">Public</span>"), 1)
         self.assertIn("sec-group-a", html)
         self.assertIn("sec-group-b", html)
-        self.assertNotIn('id="id_audience_groups_%s"' % group_public.pk, html)
+        # CheckboxSelectMultiple ids are choice indices (id_audience_groups_1), not PKs.
+        self.assertNotIn(
+            'name="audience_groups" value="%s"' % group_public.pk, html
+        )
         self.assertNotRegex(
             html,
             r'<input(?=[^>]*\bid="id_is_public")(?=[^>]*\bchecked\b)[^>]*>',
         )
         self.assertRegex(
             html,
-            r'<input(?=[^>]*\bid="id_audience_groups_%s")(?=[^>]*\bchecked\b)[^>]*>'
+            r'<input(?=[^>]*\bname="audience_groups")(?=[^>]*\bvalue="%s")(?=[^>]*\bchecked\b)[^>]*>'
             % group_a.pk,
         )
         self.assertRegex(
             html,
-            r'<input(?=[^>]*\bid="id_audience_groups_%s")(?=[^>]*\bchecked\b)[^>]*>'
+            r'<input(?=[^>]*\bname="audience_groups")(?=[^>]*\bvalue="%s")(?=[^>]*\bchecked\b)[^>]*>'
             % group_b.pk,
         )
 


### PR DESCRIPTION
## Summary
- Django \`CheckboxSelectMultiple\` assigns \`id_audience_groups_N\` by choice index; the group PK is in \`value\`.
- Update chrome audience smoke assertions accordingly (Public omitted from group list; a/b checked).

## Test plan
- [ ] \`manage.py test YSE_App.tests.test_chrome.ChromeSmokeTests.test_comment_audience_lists_all_user_groups --keepdb\`


Made with [Cursor](https://cursor.com)