### PR TITLE
feat: TransientFollowupRequest observing requests (#135)

### DIFF
--- a/YSE_App/admin.py
+++ b/YSE_App/admin.py
@@ -56,7 +56,20 @@ admin.site.register(UserTelescopeToFollow)
 admin.site.register(Host)
 admin.site.register(Transient)
 #admin.site.register(SimpleTransientSpecRequest)
-admin.site.register(TransientFollowup)
+
+
+class TransientFollowupRequestInline(admin.TabularInline):
+	model = TransientFollowupRequest
+	extra = 0
+	raw_id_fields = ('requestor',)
+
+
+@admin.register(TransientFollowup)
+class TransientFollowupAdmin(admin.ModelAdmin):
+	inlines = [TransientFollowupRequestInline]
+
+
+admin.site.register(TransientFollowupRequest)
 admin.site.register(HostFollowup)
 admin.site.register(TransientObservationTask)
 admin.site.register(HostObservationTask)

--- a/YSE_App/form_views.py
+++ b/YSE_App/form_views.py
@@ -6,6 +6,7 @@ from django.contrib.auth import authenticate, login, logout
 from django.contrib.auth.decorators import login_required
 from django.conf import settings
 from django.urls import reverse, reverse_lazy
+from django.utils.decorators import method_decorator
 import requests
 import sys
 from datetime import datetime
@@ -29,6 +30,12 @@ from django.views.decorators.csrf import csrf_exempt
 from .basicauth import *
 
 from YSE_App.util import lcogt
+from YSE_App.services.followup_requests import (
+	DEFAULT_PRIORITY,
+	create_or_attach_request,
+	format_comments,
+	format_requestors,
+)
 # for getting YSE filter selection
 from django.conf import settings as djangoSettings
 
@@ -38,6 +45,7 @@ _reddest_yse_filter = djangoSettings.REDYSEFILTER
 def is_ajax(request):
 	return request.META.get('HTTP_X_REQUESTED_WITH') == 'XMLHttpRequest'
 
+@method_decorator(login_required, name='dispatch')
 class AddTransientFollowupFormView(FormView):
 	form_class = TransientFollowupForm
 	template_name = 'YSE_App/form_snippets/transient_followup_form.html'
@@ -53,20 +61,21 @@ class AddTransientFollowupFormView(FormView):
 	def _transient_detail_success_url(self, transient):
 		return reverse("transient_detail", kwargs={"slug": transient.slug}) + "#followup_tab"
 
-	def _followup_response_data(self, instance, form):
+	def _followup_response_data(self, instance, created_parent):
 		data_dict = {
 			"id": instance.id,
 			"status_id": instance.status.id,
 			"status_name": instance.status.name,
 			"valid_start": instance.valid_start,
 			"valid_stop": instance.valid_stop,
-			"spec_priority": form.cleaned_data["spec_priority"],
-			"phot_priority": form.cleaned_data["phot_priority"],
-			"offset_star_ra": form.cleaned_data["offset_star_ra"],
-			"offset_star_dec": form.cleaned_data["offset_star_dec"],
-			"offset_north": form.cleaned_data["offset_north"],
-			"offset_east": form.cleaned_data["offset_east"],
-			"comment": form.cleaned_data["comment"],
+			"attached": not created_parent,
+			"priority": instance.priority,
+			"offset_star_ra": instance.offset_star_ra,
+			"offset_star_dec": instance.offset_star_dec,
+			"offset_north": instance.offset_north,
+			"offset_east": instance.offset_east,
+			"comment": format_comments(instance),
+			"requestors": format_requestors(instance),
 			"modified_by": instance.modified_by.username,
 		}
 		if instance.too_resource:
@@ -77,32 +86,53 @@ class AddTransientFollowupFormView(FormView):
 			data_dict["queued_resource"] = str(instance.queued_resource)
 		return data_dict
 
-	def _create_followup_from_form(self, form):
+	def _save_followup_request(self, form):
 		from YSE_App.services.audience import resolve_followup_audience
 
-		instance = form.save(commit=False)
-		instance.created_by = self.request.user
-		instance.modified_by = self.request.user
-		instance.requested_by = self.request.user
-		instance.valid_start = form.cleaned_data["valid_start"]
-		instance.valid_stop = form.cleaned_data["valid_stop"]
+		classical_resource = form.cleaned_data.get("classical_resource")
+		valid_start = form.cleaned_data["valid_start"]
+		valid_stop = form.cleaned_data["valid_stop"]
+		if classical_resource:
+			valid_start = classical_resource.begin_date_valid
+			valid_stop = classical_resource.end_date_valid
 
-		is_public, audience_groups = resolve_followup_audience(
+		priority = form.cleaned_data.get("priority")
+		if priority is None:
+			priority = DEFAULT_PRIORITY
+
+		instance, _child, created_parent = create_or_attach_request(
 			self.request.user,
-			instance.transient_id,
-			audience_groups=list(form.cleaned_data.get("audience_groups") or []),
-			linked_resource=(
-				form.cleaned_data.get("classical_resource")
-				or form.cleaned_data.get("too_resource")
-				or form.cleaned_data.get("queued_resource")
-			),
-			explicit_audience=True,
+			form.cleaned_data["transient"],
+			status=form.cleaned_data["status"],
+			valid_start=valid_start,
+			valid_stop=valid_stop,
+			priority=priority,
+			comment=form.cleaned_data.get("comment") or "",
+			classical_resource=classical_resource,
+			too_resource=form.cleaned_data.get("too_resource"),
+			queued_resource=form.cleaned_data.get("queued_resource"),
+			offset_star_ra=form.cleaned_data.get("offset_star_ra"),
+			offset_star_dec=form.cleaned_data.get("offset_star_dec"),
+			offset_north=form.cleaned_data.get("offset_north"),
+			offset_east=form.cleaned_data.get("offset_east"),
 		)
-		instance.is_public = is_public
-		instance.save()
 
-		if audience_groups:
-			instance.groups.set(audience_groups)
+		if created_parent:
+			is_public, audience_groups = resolve_followup_audience(
+				self.request.user,
+				instance.transient_id,
+				audience_groups=list(form.cleaned_data.get("audience_groups") or []),
+				linked_resource=(
+					classical_resource
+					or form.cleaned_data.get("too_resource")
+					or form.cleaned_data.get("queued_resource")
+				),
+				explicit_audience=True,
+			)
+			instance.is_public = is_public
+			instance.save(update_fields=["is_public"])
+			if audience_groups:
+				instance.groups.set(audience_groups)
 
 		if instance.transient.status.name in ["New", "Watch", "Ignore", "Interesting"]:
 			instance.transient.status = TransientStatus.objects.filter(
@@ -110,7 +140,7 @@ class AddTransientFollowupFormView(FormView):
 			)[0]
 			instance.transient.save()
 
-		if form.cleaned_data["comment"]:
+		if form.cleaned_data.get("comment"):
 			log = Log(
 				transient_followup=instance,
 				comment=form.cleaned_data["comment"],
@@ -119,7 +149,7 @@ class AddTransientFollowupFormView(FormView):
 			)
 			log.save()
 
-		return instance
+		return instance, created_parent
 
 	def form_invalid(self, form):
 		if is_ajax(self.request):
@@ -145,10 +175,10 @@ class AddTransientFollowupFormView(FormView):
 		return HttpResponseRedirect(reverse_lazy("dashboard"))
 
 	def form_valid(self, form):
-		instance = self._create_followup_from_form(form)
+		instance, created_parent = self._save_followup_request(form)
 		if is_ajax(self.request):
 			data = {
-				"data": self._followup_response_data(instance, form),
+				"data": self._followup_response_data(instance, created_parent),
 				"message": "Successfully submitted form data.",
 			}
 			return JsonResponse(data)
@@ -794,17 +824,17 @@ class AddAutomatedSpectrumRequestFormView(FormView):
 				resource = resource[0]
 			
 			status = FollowupStatus.objects.get(name='Requested')
-
-			if 'goodman' in form.cleaned_data['instrument'].name.lower():
-				tf = TransientFollowup(status=status,valid_start=form.cleaned_data['spectrum_valid_start'],
-									   valid_stop=form.cleaned_data['spectrum_valid_stop'],classical_resource=resource,
-									   transient=form.cleaned_data['transient'],created_by=self.request.user,modified_by=self.request.user)
-			else:
-				tf = TransientFollowup(status=status,valid_start=form.cleaned_data['spectrum_valid_start'],
-									   valid_stop=form.cleaned_data['spectrum_valid_stop'],too_resource=resource,
-									   transient=form.cleaned_data['transient'],created_by=self.request.user,modified_by=self.request.user)
-
-			tf.save()
+			is_goodman = 'goodman' in form.cleaned_data['instrument'].name.lower()
+			tf, _child, _created = create_or_attach_request(
+				self.request.user,
+				form.cleaned_data['transient'],
+				status=status,
+				valid_start=form.cleaned_data['spectrum_valid_start'],
+				valid_stop=form.cleaned_data['spectrum_valid_stop'],
+				priority=DEFAULT_PRIORITY,
+				classical_resource=resource if is_goodman else None,
+				too_resource=None if is_goodman else resource,
+			)
 
 			# now charlie's code
 			lcogt.main(

--- a/YSE_App/forms.py
+++ b/YSE_App/forms.py
@@ -53,7 +53,16 @@ class TransientFollowupForm(ModelForm):
         required=False)
     valid_start = forms.DateTimeField(required=False)
     valid_stop = forms.DateTimeField(required=False)
-    comment = forms.CharField(required=False)
+    comment = forms.CharField(
+        required=False,
+        widget=forms.TextInput(attrs={'autocomplete': 'off'}),
+    )
+    priority = forms.FloatField(
+        initial=4.0,
+        min_value=1.0,
+        max_value=5.0,
+        widget=forms.NumberInput(attrs={'step': '0.1', 'min': '1.0', 'max': '5.0'}),
+    )
 
     def __init__(self, *args, user=None, transient_id=None, **kwargs):
         super().__init__(*args, **kwargs)
@@ -206,8 +215,7 @@ class TransientFollowupForm(ModelForm):
             'comment',
             'valid_start',
             'valid_stop',
-            'spec_priority',
-            'phot_priority',
+            'priority',
             'offset_star_ra',
             'offset_star_dec',
             'offset_north',

--- a/YSE_App/migrations/0008_followup_requests.py
+++ b/YSE_App/migrations/0008_followup_requests.py
@@ -1,0 +1,162 @@
+from django.conf import settings
+from django.db import migrations, models
+import django.core.validators
+import django.db.models.deletion
+
+
+def _priority_from_legacy(spec_priority, phot_priority):
+    values = [float(v) for v in (spec_priority, phot_priority) if v is not None]
+    if not values:
+        return 4.0
+    priority = min(values)
+    return max(1.0, min(5.0, priority))
+
+
+def backfill_followup_requests(apps, schema_editor):
+    TransientFollowup = apps.get_model("YSE_App", "TransientFollowup")
+    HostFollowup = apps.get_model("YSE_App", "HostFollowup")
+    TransientFollowupRequest = apps.get_model("YSE_App", "TransientFollowupRequest")
+    Log = apps.get_model("YSE_App", "Log")
+
+    for followup in HostFollowup.objects.all().iterator():
+        followup.priority = _priority_from_legacy(
+            followup.spec_priority, followup.phot_priority
+        )
+        followup.save(update_fields=["priority"])
+
+    for followup in TransientFollowup.objects.all().iterator():
+        priority = _priority_from_legacy(followup.spec_priority, followup.phot_priority)
+        followup.priority = priority
+        followup.save(update_fields=["priority"])
+
+        comments = list(
+            Log.objects.filter(transient_followup_id=followup.id)
+            .exclude(comment="")
+            .values_list("comment", flat=True)
+        )
+        comment = "; ".join(comments)
+        requestor_id = followup.requested_by_id or followup.created_by_id
+        req = TransientFollowupRequest.objects.create(
+            followup=followup,
+            requestor_id=requestor_id,
+            priority=priority,
+            comment=comment,
+            created_by_id=followup.created_by_id,
+            modified_by_id=followup.modified_by_id,
+        )
+        TransientFollowupRequest.objects.filter(pk=req.pk).update(
+            requested_at=followup.created_date,
+            created_date=followup.created_date,
+        )
+
+
+def noop_reverse(apps, schema_editor):
+    pass
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+        ("YSE_App", "0007_resource_creator_only"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="hostfollowup",
+            name="priority",
+            field=models.FloatField(blank=True, null=True),
+        ),
+        migrations.AddField(
+            model_name="transientfollowup",
+            name="priority",
+            field=models.FloatField(blank=True, null=True),
+        ),
+        migrations.CreateModel(
+            name="TransientFollowupRequest",
+            fields=[
+                (
+                    "id",
+                    models.AutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name="ID",
+                    ),
+                ),
+                ("created_date", models.DateTimeField(auto_now_add=True)),
+                ("modified_date", models.DateTimeField(auto_now=True)),
+                ("requested_at", models.DateTimeField(auto_now_add=True)),
+                (
+                    "priority",
+                    models.FloatField(
+                        default=4.0,
+                        validators=[
+                            django.core.validators.MinValueValidator(1.0),
+                            django.core.validators.MaxValueValidator(5.0),
+                        ],
+                    ),
+                ),
+                ("comment", models.TextField(blank=True)),
+                (
+                    "created_by",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.PROTECT,
+                        related_name="%(class)s_created_by",
+                        to=settings.AUTH_USER_MODEL,
+                    ),
+                ),
+                (
+                    "followup",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="requests",
+                        to="YSE_App.transientfollowup",
+                    ),
+                ),
+                (
+                    "modified_by",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.PROTECT,
+                        related_name="%(class)s_modified_by",
+                        to=settings.AUTH_USER_MODEL,
+                    ),
+                ),
+                (
+                    "requestor",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.PROTECT,
+                        related_name="transient_followup_requests",
+                        to=settings.AUTH_USER_MODEL,
+                    ),
+                ),
+            ],
+            options={
+                "ordering": ["requested_at", "id"],
+            },
+        ),
+        migrations.AddIndex(
+            model_name="transientfollowuprequest",
+            index=models.Index(
+                fields=["followup", "requestor", "-requested_at"],
+                name="YSE_App_tra_followu_7c9a1e_idx",
+            ),
+        ),
+        migrations.RunPython(backfill_followup_requests, noop_reverse),
+        migrations.RemoveField(
+            model_name="hostfollowup",
+            name="phot_priority",
+        ),
+        migrations.RemoveField(
+            model_name="hostfollowup",
+            name="spec_priority",
+        ),
+        migrations.RemoveField(
+            model_name="transientfollowup",
+            name="phot_priority",
+        ),
+        migrations.RemoveField(
+            model_name="transientfollowup",
+            name="spec_priority",
+        ),
+    ]

--- a/YSE_App/models/__init__.py
+++ b/YSE_App/models/__init__.py
@@ -2,6 +2,7 @@ from YSE_App.models.base import *
 from YSE_App.models.additional_info_models import *
 from YSE_App.models.enum_models import *
 from YSE_App.models.followup_models import *
+from YSE_App.models.followup_models import TransientFollowupRequest
 from YSE_App.models.host_models import *
 from YSE_App.models.instrument_models import *
 from YSE_App.models.log_models import *

--- a/YSE_App/models/followup_models.py
+++ b/YSE_App/models/followup_models.py
@@ -1,4 +1,6 @@
+from django.core.validators import MaxValueValidator, MinValueValidator
 from django.db import models
+from django.dispatch import receiver
 from django.contrib.auth.models import Group
 from django.contrib.auth.models import User
 from YSE_App.models.base import *
@@ -34,8 +36,7 @@ class Followup(BaseModel):
 	valid_stop = models.DateTimeField()
 
 	# Optional
-	spec_priority = models.IntegerField(null=True, blank=True)
-	phot_priority = models.IntegerField(null=True, blank=True)
+	priority = models.FloatField(null=True, blank=True)
 	offset_star_ra = models.FloatField(null=True, blank=True)
 	offset_star_dec = models.FloatField(null=True, blank=True)
 	offset_north = models.FloatField(null=True, blank=True)
@@ -58,6 +59,43 @@ class TransientFollowup(Followup):
 
 	def observation_window(self):
 		return "%s - %s" % (self.valid_start.strftime('%m/%d/%Y'), self.valid_stop.strftime('%m/%d/%Y'))		
+
+class TransientFollowupRequest(BaseModel):
+	"""One observing-request submit attached to a parent TransientFollowup.
+
+	Same user may have many rows. Display priority is min of each
+	requestor's most recent ``priority`` (1.0 highest, 5.0 lowest).
+	"""
+
+	class Meta:
+		ordering = ['requested_at', 'id']
+		indexes = [
+			models.Index(fields=['followup', 'requestor', '-requested_at']),
+		]
+
+	followup = models.ForeignKey(
+		TransientFollowup,
+		on_delete=models.CASCADE,
+		related_name='requests',
+	)
+	requestor = models.ForeignKey(
+		User,
+		on_delete=models.PROTECT,
+		related_name='transient_followup_requests',
+	)
+	requested_at = models.DateTimeField(auto_now_add=True)
+	priority = models.FloatField(
+		default=4.0,
+		validators=[MinValueValidator(1.0), MaxValueValidator(5.0)],
+	)
+	comment = models.TextField(blank=True)
+
+	def __str__(self):
+		return "Followup request: [%s] by %s at %s" % (
+			self.followup_id,
+			self.requestor,
+			self.requested_at,
+		)
 
 @receiver(models.signals.post_save, sender=TransientFollowup)
 def execute_after_save(sender, instance, created, *args, **kwargs):

--- a/YSE_App/serializers/followup_serializers.py
+++ b/YSE_App/serializers/followup_serializers.py
@@ -1,30 +1,32 @@
 from rest_framework import serializers
 from YSE_App.models import *
-from django.contrib.auth.models import User
 
-#class SimpleTransientSpecRequestSerializer(serializers.HyperlinkedModelSerializer):
-#	transient = serializers.HyperlinkedRelatedField(queryset=Transient.objects.all(), view_name='transient-detail')
-#	status = serializers.HyperlinkedRelatedField(queryset=FollowupStatus.objects.all(), view_name='followupstatus-detail')
-#
-#	created_by = serializers.HyperlinkedRelatedField(read_only=True, view_name='user-detail')
-#	modified_by = serializers.HyperlinkedRelatedField(read_only=True, view_name='user-detail')
-#
-#	class Meta:
-#		model = SimpleTransientSpecRequest
-#		fields = "__all__"
-#
-#	def create(self, validated_data):
-#		return SimpleTransientSpecRequest.objects.create(**validated_data)
-#
-#	def update(self, instance, validated_data):
-#		instance.transient_id = validated_data.get('transient', instance.transient)
-#		instance.status_id = validated_data.get('status', instance.status)
-#
-#		instance.modified_by_id = validated_data.get('modified_by', instance.modified_by)
-#		
-#		instance.save()
-#
-#		return instance
+# Do not import YSE_App.services.followup_requests at module top.
+# URLconf load: views -> yse_pa -> table_utils -> view_utils -> serializers;
+# a top-level service import races the models package and raises
+# ImportError: cannot import name TransientFollowupRequest.
+
+DEFAULT_PRIORITY = 4.0
+
+
+class TransientFollowupRequestSerializer(serializers.HyperlinkedModelSerializer):
+	requestor = serializers.HyperlinkedRelatedField(read_only=True, view_name='user-detail')
+	created_by = serializers.HyperlinkedRelatedField(read_only=True, view_name='user-detail')
+	modified_by = serializers.HyperlinkedRelatedField(read_only=True, view_name='user-detail')
+
+	class Meta:
+		model = TransientFollowupRequest
+		fields = (
+			'id',
+			'requestor',
+			'requested_at',
+			'priority',
+			'comment',
+			'created_by',
+			'modified_by',
+		)
+		read_only_fields = fields
+
 
 class TransientFollowupSerializer(serializers.HyperlinkedModelSerializer):
 	transient = serializers.HyperlinkedRelatedField(queryset=Transient.objects.all(), view_name='transient-detail')
@@ -36,13 +38,46 @@ class TransientFollowupSerializer(serializers.HyperlinkedModelSerializer):
 
 	created_by = serializers.HyperlinkedRelatedField(read_only=True, view_name='user-detail')
 	modified_by = serializers.HyperlinkedRelatedField(read_only=True, view_name='user-detail')
+	requests = TransientFollowupRequestSerializer(many=True, read_only=True)
 
 	class Meta:
 		model = TransientFollowup
 		fields = "__all__"
 
 	def create(self, validated_data):
-		return TransientFollowup.objects.create(**validated_data)
+		# Circular: see module comment. Service import must stay in this method.
+		from YSE_App.services.followup_requests import create_or_attach_request
+
+		user = validated_data.pop('created_by', None)
+		validated_data.pop('modified_by', None)
+		if user is None:
+			user = self.context['request'].user
+		priority = validated_data.pop('priority', None)
+		if priority is None:
+			priority = DEFAULT_PRIORITY
+		is_public = validated_data.pop('is_public', None)
+		groups = validated_data.pop('groups', None)
+		parent, _child, _created = create_or_attach_request(
+			user,
+			validated_data.pop('transient'),
+			status=validated_data.pop('status'),
+			valid_start=validated_data.pop('valid_start'),
+			valid_stop=validated_data.pop('valid_stop'),
+			priority=priority,
+			classical_resource=validated_data.pop('classical_resource', None),
+			too_resource=validated_data.pop('too_resource', None),
+			queued_resource=validated_data.pop('queued_resource', None),
+			offset_star_ra=validated_data.pop('offset_star_ra', None),
+			offset_star_dec=validated_data.pop('offset_star_dec', None),
+			offset_north=validated_data.pop('offset_north', None),
+			offset_east=validated_data.pop('offset_east', None),
+		)
+		if is_public is not None and parent.is_public != is_public:
+			parent.is_public = is_public
+			parent.save(update_fields=['is_public'])
+		if groups is not None:
+			parent.groups.set(groups)
+		return parent
 
 	def update(self, instance, validated_data):
 		instance.transient_id = validated_data.get('transient', instance.transient)
@@ -53,8 +88,6 @@ class TransientFollowupSerializer(serializers.HyperlinkedModelSerializer):
 
 		instance.valid_start = validated_data.get('valid_start', instance.valid_start)
 		instance.valid_stop = validated_data.get('valid_stop', instance.valid_stop)
-		instance.spec_priority = validated_data.get('spec_priority', instance.spec_priority)
-		instance.phot_priority = validated_data.get('phot_priority', instance.phot_priority)
 		instance.offset_star_ra = validated_data.get('offset_star_ra', instance.offset_star_ra)
 		instance.offset_star_dec = validated_data.get('offset_star_dec', instance.offset_star_dec)
 		instance.offset_north = validated_data.get('offset_north', instance.offset_north)
@@ -93,8 +126,7 @@ class HostFollowupSerializer(serializers.HyperlinkedModelSerializer):
 
 		instance.valid_start = validated_data.get('valid_start', instance.valid_start)
 		instance.valid_stop = validated_data.get('valid_stop', instance.valid_stop)
-		instance.spec_priority = validated_data.get('spec_priority', instance.spec_priority)
-		instance.phot_priority = validated_data.get('phot_priority', instance.phot_priority)
+		instance.priority = validated_data.get('priority', instance.priority)
 		instance.offset_star_ra = validated_data.get('offset_star_ra', instance.offset_star_ra)
 		instance.offset_star_dec = validated_data.get('offset_star_dec', instance.offset_star_dec)
 		instance.offset_north = validated_data.get('offset_north', instance.offset_north)

--- a/YSE_App/services/followup_requests.py
+++ b/YSE_App/services/followup_requests.py
@@ -1,0 +1,284 @@
+"""Create/attach TransientFollowupRequest children and display helpers.
+
+Parent ``TransientFollowup`` holds status, resource, and window. Each form
+or API submit inserts a new child (same user may have many). Display
+priority is the minimum of each requestor's most recent child priority
+(1.0 highest, 5.0 lowest).
+"""
+
+from __future__ import annotations
+
+from typing import Iterable, List, Optional, Tuple
+
+from django.contrib.auth.models import User
+from django.core.exceptions import ValidationError
+from django.db.models import QuerySet
+# Import model modules directly. ``from YSE_App.models import TransientFollowupRequest``
+# fails during URLconf load: views -> yse_pa -> table_utils -> view_utils ->
+# serializers -> this module, while ``YSE_App.models`` package namespace is stale
+# or still initializing.
+from YSE_App.models.enum_models import FollowupStatus
+from YSE_App.models.followup_models import TransientFollowup, TransientFollowupRequest
+from YSE_App.models.transient_models import Transient
+
+DEFAULT_PRIORITY = 4.0
+PRIORITY_MIN = 1.0
+PRIORITY_MAX = 5.0
+TERMINAL_FOLLOWUP_STATUSES = frozenset({"Successful", "Failed", "StatusDeleted"})
+
+
+def validate_priority(priority: float) -> float:
+    """Return ``priority`` if it is in ``[1.0, 5.0]``.
+
+    Parameters
+    ----------
+    priority:
+        Requested observing priority (1.0 highest).
+
+    Returns
+    -------
+    float
+        The same value, coerced to float.
+
+    Raises
+    ------
+    ValidationError
+        If ``priority`` is outside 1.0–5.0.
+    """
+    value = float(priority)
+    if value < PRIORITY_MIN or value > PRIORITY_MAX:
+        raise ValidationError(
+            f"priority must be between {PRIORITY_MIN} and {PRIORITY_MAX} (got {value})."
+        )
+    return value
+
+
+def find_active_parent(
+    transient: Transient,
+    *,
+    classical_resource=None,
+    too_resource=None,
+    queued_resource=None,
+) -> Optional[TransientFollowup]:
+    """Return the newest non-terminal parent for this transient+resource.
+
+    Parameters
+    ----------
+    transient:
+        Target transient.
+    classical_resource, too_resource, queued_resource:
+        Resource FKs to match exactly (including None).
+
+    Returns
+    -------
+    TransientFollowup or None
+        Newest active parent, or None if none exists.
+    """
+    return (
+        TransientFollowup.objects.filter(
+            transient=transient,
+            classical_resource=classical_resource,
+            too_resource=too_resource,
+            queued_resource=queued_resource,
+        )
+        .exclude(status__name__in=TERMINAL_FOLLOWUP_STATUSES)
+        .order_by("-id")
+        .first()
+    )
+
+
+def effective_priority(followup: TransientFollowup) -> Optional[float]:
+    """Min of each requestor's most recent child priority.
+
+    Parameters
+    ----------
+    followup:
+        Parent follow-up. Prefetch ``requests`` to avoid extra queries.
+
+    Returns
+    -------
+    float or None
+        Consolidated priority, or the denormalized parent value if no children.
+    """
+    requests = list(followup.requests.all())
+    if not requests:
+        return followup.priority
+    latest_by_user = {}
+    for req in sorted(requests, key=lambda row: (row.requested_at, row.id), reverse=True):
+        if req.requestor_id not in latest_by_user:
+            latest_by_user[req.requestor_id] = req.priority
+    if not latest_by_user:
+        return followup.priority
+    return min(latest_by_user.values())
+
+
+def recompute_parent_priority(followup: TransientFollowup) -> Optional[float]:
+    """Write ``effective_priority`` onto the parent and return it.
+
+    Parameters
+    ----------
+    followup:
+        Parent to update. ``priority`` is saved with ``update_fields``.
+
+    Returns
+    -------
+    float or None
+        New denormalized priority.
+    """
+    priority = effective_priority(followup)
+    if followup.priority != priority:
+        followup.priority = priority
+        followup.save(update_fields=["priority"])
+    return priority
+
+
+def format_requestors(followup: TransientFollowup) -> str:
+    """Comma-separated unique requestor usernames in first-request order.
+
+    Parameters
+    ----------
+    followup:
+        Parent follow-up.
+
+    Returns
+    -------
+    str
+        Display string, empty if there are no children.
+    """
+    seen = []
+    for req in _ordered_requests(followup):
+        name = str(req.requestor)
+        if name not in seen:
+            seen.append(name)
+    return ", ".join(seen)
+
+
+def format_comments(followup: TransientFollowup) -> str:
+    """Join child comments as ``user: text``.
+
+    Empty comments are omitted. Order is ``requested_at`` ascending.
+
+    Parameters
+    ----------
+    followup:
+        Parent follow-up.
+
+    Returns
+    -------
+    str
+        Semicolon-separated labeled comments.
+    """
+    parts: List[str] = []
+    for req in _ordered_requests(followup):
+        text = (req.comment or "").strip()
+        if not text:
+            continue
+        parts.append(f"{req.requestor}: {text}")
+    return "; ".join(parts)
+
+
+def create_or_attach_request(
+    user: User,
+    transient: Transient,
+    *,
+    status: FollowupStatus,
+    valid_start,
+    valid_stop,
+    priority: float = DEFAULT_PRIORITY,
+    comment: str = "",
+    classical_resource=None,
+    too_resource=None,
+    queued_resource=None,
+    offset_star_ra=None,
+    offset_star_dec=None,
+    offset_north=None,
+    offset_east=None,
+) -> Tuple[TransientFollowup, TransientFollowupRequest, bool]:
+    """Insert a child request; create an active parent only if needed.
+
+    Attaching to an existing parent does not change parent status, window,
+    or offsets. ``requested_by`` is set on the first child only.
+
+    Parameters
+    ----------
+    user:
+        Requestor (also stamps ``created_by`` / ``modified_by``).
+    transient:
+        Target transient.
+    status:
+        Used only when creating a new parent.
+    valid_start, valid_stop:
+        Validity window for a new parent.
+    priority:
+        Child priority, 1.0–5.0 (default 4.0).
+    comment:
+        Child comment (may be empty).
+    classical_resource, too_resource, queued_resource:
+        Resource FKs that key the active parent.
+    offset_star_ra, offset_star_dec, offset_north, offset_east:
+        Offset fields for a new parent.
+
+    Returns
+    -------
+    tuple
+        ``(parent, child, created_parent)``.
+
+    Raises
+    ------
+    ValidationError
+        If ``priority`` is outside 1.0–5.0.
+    """
+    priority = validate_priority(priority)
+    comment = comment or ""
+
+    parent = find_active_parent(
+        transient,
+        classical_resource=classical_resource,
+        too_resource=too_resource,
+        queued_resource=queued_resource,
+    )
+    created_parent = parent is None
+    if created_parent:
+        parent = TransientFollowup(
+            transient=transient,
+            status=status,
+            valid_start=valid_start,
+            valid_stop=valid_stop,
+            classical_resource=classical_resource,
+            too_resource=too_resource,
+            queued_resource=queued_resource,
+            offset_star_ra=offset_star_ra,
+            offset_star_dec=offset_star_dec,
+            offset_north=offset_north,
+            offset_east=offset_east,
+            requested_by=user,
+            created_by=user,
+            modified_by=user,
+        )
+        parent.save()
+    else:
+        parent.modified_by = user
+        parent.save(update_fields=["modified_by", "modified_date"])
+        if parent.requested_by_id is None:
+            parent.requested_by = user
+            parent.save(update_fields=["requested_by"])
+
+    child = TransientFollowupRequest(
+        followup=parent,
+        requestor=user,
+        priority=priority,
+        comment=comment,
+        created_by=user,
+        modified_by=user,
+    )
+    child.save()
+    recompute_parent_priority(parent)
+    parent.refresh_from_db()
+    return parent, child, created_parent
+
+
+def _ordered_requests(followup: TransientFollowup) -> Iterable[TransientFollowupRequest]:
+    requests = followup.requests.all()
+    if isinstance(requests, QuerySet):
+        return requests.select_related("requestor").order_by("requested_at", "id")
+    return sorted(requests, key=lambda row: (row.requested_at, row.id))

--- a/YSE_App/services/visibility.py
+++ b/YSE_App/services/visibility.py
@@ -292,9 +292,10 @@ def filter_transient_followups_for_user(queryset: QuerySet, user: User) -> Query
         is_public=False,
         requested_by=user,
     )
+    child_requestor = scoped.filter(requests__requestor=user)
     legacy_ids = _legacy_public_followup_ids(user)
     legacy = scoped.filter(pk__in=legacy_ids) if legacy_ids else scoped.none()
-    return (by_audience | creator_only | legacy).distinct()
+    return (by_audience | creator_only | child_requestor | legacy).distinct()
 
 
 def followup_visible_to_user(user: User, followup) -> bool:
@@ -305,6 +306,8 @@ def followup_visible_to_user(user: User, followup) -> bool:
     transient_id = getattr(followup, "transient_id", None)
     if transient_id is not None and not user_can_view_transient(user, transient_id):
         return False
+    if followup.requests.filter(requestor=user).exists():
+        return True
     if not user_can_see_linked_followup_resource(user, followup):
         return False
     if object_has_groups(followup):

--- a/YSE_App/static/YSE_App/yse-theme.css
+++ b/YSE_App/static/YSE_App/yse-theme.css
@@ -732,10 +732,51 @@ body.yse-theme .content {
 body.yse-theme .yse-page-dashboard .btn-group .btn,
 body.yse-theme .yse-page-dashboard .dropdown-toggle,
 body.yse-theme .yse-page-dashboard .btn-default,
-body.yse-theme .yse-page-dashboard .btn-secondary.dropdown-toggle {
+body.yse-theme .yse-page-dashboard .btn-secondary.dropdown-toggle,
+body.yse-theme .yse-page-observing-night .btn-group .btn,
+body.yse-theme .yse-page-observing-night .dropdown-toggle,
+body.yse-theme .yse-page-observing-night .btn-default,
+body.yse-theme .yse-page-observing-night .btn-secondary.dropdown-toggle,
+body.yse-theme .content .btn-group .dropdown-toggle,
+body.yse-theme .content .btn-secondary.dropdown-toggle,
+body.yse-theme table .btn-group .btn,
+body.yse-theme table .btn-group .dropdown-toggle,
+body.yse-theme table .btn-group .dropbtn {
   font-size: var(--yse-font-size-xs) !important;
   line-height: 1.2;
   padding: 1px 6px;
+}
+
+body.yse-theme table .dropdown-menu,
+body.yse-theme table .dropdown-menu > li > a,
+body.yse-theme .yse-page-observing-night .dropdown-menu,
+body.yse-theme .yse-page-observing-night .dropdown-menu > li > a {
+  font-size: var(--yse-font-size-xs) !important;
+}
+
+body.yse-theme .yse-page-observing-night .yse-obs-night-toolbar {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: var(--yse-space-md);
+  margin: 0 0 var(--yse-space-md);
+  padding: 0;
+}
+
+body.yse-theme .yse-page-observing-night .yse-obs-night-toolbar .btn {
+  margin: 0;
+  width: auto;
+}
+
+body.yse-theme .yse-page-observing-night .yse-obs-night-filter {
+  margin: var(--yse-space-sm) 0 0;
+  display: flex;
+  align-items: center;
+  gap: var(--yse-space-sm);
+}
+
+body.yse-theme .yse-page-observing-night .yse-obs-night-filter .form-group {
+  margin: 0;
 }
 
 body.yse-theme .btn-default {

--- a/YSE_App/table_utils.py
+++ b/YSE_App/table_utils.py
@@ -20,6 +20,8 @@ from matplotlib.dates import DateFormatter
 from matplotlib import rcParams
 from django.db.models.expressions import RawSQL
 from .common.magnitude_format import format_magnitude
+# Circular: table_utils is imported from yse_pa during views import, before
+# follow-up request helpers are safe to load. Import in render methods.
 rcParams['figure.figsize'] = (7,7)
 
 
@@ -495,13 +497,16 @@ class YSETransientTable(tables.Table):
         return ', '.join(np.unique(resource_list))
 
     def render_followup_comments(self, value):
-        qs = Log.objects.filter(transient_followup__transient__id=value).values_list('comment')
+        from YSE_App.services.followup_requests import format_comments
 
-        comment_list = []
-        for q in qs:
-            if q is not None: comment_list += [q]
-
-        return '; '.join(np.unique(comment_list))
+        comments = []
+        for followup in TransientFollowup.objects.filter(transient__id=value).prefetch_related(
+            'requests__requestor'
+        ):
+            text = format_comments(followup)
+            if text:
+                comments.append(text)
+        return '; '.join(comments)
 
 
     def order_recent_mag(self, queryset, is_descending):
@@ -1079,8 +1084,9 @@ class ObsNightFollowupTable(tables.Table):
     rise_time = tables.Column(verbose_name='Rise Time (UT)',orderable=False,accessor='transient.CoordString')
     set_time = tables.Column(verbose_name='Set Time (UT)',orderable=False,accessor='transient.CoordString')
     moon_angle = tables.Column(verbose_name='Moon Angle',orderable=False,accessor='transient.CoordString')
-    created_by = tables.Column(verbose_name='Added By',orderable=True,accessor='created_by')
-    comment = tables.Column(verbose_name='Comments',orderable=True,accessor='id')
+    requestors = tables.Column(verbose_name='Requestors',orderable=False,accessor='id')
+    priority = tables.Column(verbose_name='Priority',orderable=True,accessor='priority')
+    comment = tables.Column(verbose_name='Comments',orderable=False,accessor='id')
 
     transient_status_string = tables.TemplateColumn("""<div class="btn-group">
 <button style="margin-bottom:-5px;margin-top:-10px;padding:1px 5px" type="button" class="btn btn-secondary btn-sm dropdown-toggle" data-toggle="dropdown">
@@ -1154,15 +1160,15 @@ class ObsNightFollowupTable(tables.Table):
     def render_airmass(self, value):
         from astroplan.plots import plot_airmass
 
-    def render_comment(self, value):
+    def render_requestors(self, value, record):
+        from YSE_App.services.followup_requests import format_requestors
 
-        comments = Log.objects.filter(transient_followup__id=value)
-        comment_list = []
-        for c in comments:
-            comment_list += [c.comment]
-        if len(comment_list): return '; '.join(comment_list)
-        else: return ''
+        return format_requestors(record)
 
+    def render_comment(self, value, record):
+        from YSE_App.services.followup_requests import format_comments
+
+        return format_comments(record)
 
     def order_recent_mag(self, queryset, is_descending):
 
@@ -1186,7 +1192,7 @@ SELECT pd.mag
         model = TransientFollowup
         fields = ('name_string','ra_string','dec_string','recent_mag',
                   'rise_time','set_time','moon_angle','transient_status_string',
-                  'created_by')
+                  'requestors','priority','comment')
         template_name='YSE_App/django-tables2/bootstrap.html'
         attrs = {
             'th' : {
@@ -1222,8 +1228,9 @@ class ToOFollowupTable(tables.Table):
     rise_time = tables.Column(verbose_name='Rise Time (UT)',orderable=False,accessor='transient.CoordString')
     set_time = tables.Column(verbose_name='Set Time (UT)',orderable=False,accessor='transient.CoordString')
     moon_angle = tables.Column(verbose_name='Moon Angle',orderable=False,accessor='transient.CoordString')
-    created_by = tables.Column(verbose_name='Added By',orderable=True,accessor='created_by')
-    comment = tables.Column(verbose_name='Comments',orderable=True,accessor='id')
+    requestors = tables.Column(verbose_name='Requestors',orderable=False,accessor='id')
+    priority = tables.Column(verbose_name='Priority',orderable=True,accessor='priority')
+    comment = tables.Column(verbose_name='Comments',orderable=False,accessor='id')
 
     transient_status_string = tables.TemplateColumn("""<div class="btn-group">
 <button style="margin-bottom:-5px;margin-top:-10px;padding:1px 5px" type="button" class="btn btn-secondary btn-sm dropdown-toggle" data-toggle="dropdown">
@@ -1290,15 +1297,15 @@ class ToOFollowupTable(tables.Table):
     def render_airmass(self, value):
         from astroplan.plots import plot_airmass
 
-    def render_comment(self, value):
+    def render_requestors(self, value, record):
+        from YSE_App.services.followup_requests import format_requestors
 
-        comments = Log.objects.filter(transient_followup__id=value)
-        comment_list = []
-        for c in comments:
-            comment_list += [c.comment]
-        if len(comment_list): return '; '.join(comment_list)
-        else: return ''
+        return format_requestors(record)
 
+    def render_comment(self, value, record):
+        from YSE_App.services.followup_requests import format_comments
+
+        return format_comments(record)
 
     def order_recent_mag(self, queryset, is_descending):
 
@@ -1322,7 +1329,7 @@ SELECT pd.mag
         model = TransientFollowup
         fields = ('name_string','ra_string','dec_string','recent_mag',
                   'rise_time','set_time','moon_angle','transient_status_string',
-                  'created_by')
+                  'requestors','priority','comment')
         template_name='YSE_App/django-tables2/bootstrap.html'
         attrs = {
             'th' : {
@@ -1340,7 +1347,7 @@ SELECT pd.mag
             "order": [[ 2, "desc" ]],
         }
 
-        
+
 
 class YSEObsNightTable(tables.Table):
 

--- a/YSE_App/templates/YSE_App/base.html
+++ b/YSE_App/templates/YSE_App/base.html
@@ -31,7 +31,7 @@
 	<link rel="stylesheet" href="{% static 'YSE_App/bower_components/Ionicons/css/ionicons.min.css' %}">
 	<link rel="stylesheet" href="{% static 'YSE_App/vendor/datatables-bs4/dataTables.bootstrap4.min.css' %}">
 	<link rel="stylesheet" href="{% static 'YSE_App/vendor/adminlte-3.2/css/adminlte.min.css' %}">
-	<link rel="stylesheet" href="{% static 'YSE_App/yse-theme.css' %}?v=tags-1">
+	<link rel="stylesheet" href="{% static 'YSE_App/yse-theme.css' %}?v=obs-night-2">
 	<link rel="stylesheet" href="{% static 'YSE_App/bower_components/morris.js/morris.css' %}">
 	<link rel="stylesheet" href="{% static 'YSE_App/bower_components/jvectormap/jquery-jvectormap.css' %}">
 	<link rel="stylesheet" href="{% static 'YSE_App/bower_components/bootstrap-datepicker/dist/css/bootstrap-datepicker.min.css' %}">

--- a/YSE_App/templates/YSE_App/form_snippets/transient_followup_form.html
+++ b/YSE_App/templates/YSE_App/form_snippets/transient_followup_form.html
@@ -41,8 +41,14 @@
 				</div>
 				<div class="col-6">
 					<div class="form-group">
+						<label>Priority (1.0 highest, 5.0 lowest)</label>
+						{% render_field form.priority class+="form-control" style+="width: 100%;" %}
+					</div>
+				</div>
+				<div class="col-6">
+					<div class="form-group">
 						<label>Comments</label>
-						{% render_field form.comment class+="form-control select2" style+="width: 100%;" %}
+						{% render_field form.comment class+="form-control" style+="width: 100%;" %}
 					</div>
 				</div>
 				<div class="col-6">

--- a/YSE_App/templates/YSE_App/observing_night.html
+++ b/YSE_App/templates/YSE_App/observing_night.html
@@ -51,28 +51,17 @@
       <!-- Default box -->
     {% if followup_table.3|length %}
     <div class="box" id="{{followup_table.2}}">
-    <div class="col-3">
-    <div class="box-header with-border">
-       <input class="btn btn-block btn-primary" type="button" value="Download Target List" onclick="window.open('{% url 'download_target_list' classical_obs_date.resource.telescope|replace_space obs_date %}')">
-    </div>
-  </div>
-    <!--<div class="col-3">
-    <div class="box-header with-border">
-       <input class="btn btn-block btn-primary" type="button" value="Download Target List and Finder Charts" onclick="window.open('{% url 'download_target_list' classical_obs_date.resource.telescope|replace_space obs_date %}')">
-    </div>
-  </div>-->
-      <div align='right'>
-      {% if followup_table.4 %}
-      <form action="" method="get" class="form form-inline">
-        {% bootstrap_form followup_table.4.form layout='inline' %}
-        {% bootstrap_button 'filter' %}&ensp;&nbsp;
-      </form>
-      {% endif %}
-    </div>
     <div class="box-body">
-
+      <div class="yse-obs-night-toolbar">
+        <input class="btn btn-primary" type="button" value="Download Target List" onclick="window.open('{% url 'download_target_list' classical_obs_date.resource.telescope|replace_space obs_date %}')">
+        {% if followup_table.4 %}
+        <form action="" method="get" class="form form-inline yse-obs-night-filter" style="margin-top: 12px;">
+          {% bootstrap_form followup_table.4.form layout='inline' %}
+          {% bootstrap_button 'filter' %}
+        </form>
+        {% endif %}
+      </div>
       {% render_table followup_table.1 %}
-
     </div>
     <!-- /.box-body -->
     <div class="box-footer">

--- a/YSE_App/templates/YSE_App/transient_detail.html
+++ b/YSE_App/templates/YSE_App/transient_detail.html
@@ -412,6 +412,11 @@
                 return;
             }
             yseFollowupClearSubmitError();
+            var fdr_picker = $('#follow_date_range').data('daterangepicker');
+            if (fdr_picker) {
+                $('#valid_start').val(fdr_picker.startDate.format("YYYY-MM-DD HH:mm:00"));
+                $('#valid_stop').val(fdr_picker.endDate.format("YYYY-MM-DD HH:mm:00"));
+            }
             var submitUrl = $form.attr('action') || "{% url 'add_transient_followup' %}";
             var data = $form.serialize();
             var transient_id = $form.find('input[name="transient"]').val() || $('#transient_pk').val();
@@ -1877,6 +1882,7 @@
                 var valid_start = json.data["valid_start"];
                 var valid_stop = json.data["valid_stop"];
                 var modified_by = json.data["modified_by"];
+                var requestors = json.data["requestors"] ? json.data["requestors"] : modified_by;
 
                 if (!followup_pk || !status_id || !status_name ||
                     !valid_start || !valid_stop || !modified_by) {
@@ -1887,13 +1893,8 @@
                 var too_resource = json.data["too_resource"];
                 var classical_resource = json.data["classical_resource"];
                 var queued_resource = json.data["queued_resource"];
-                var spec_priority = json.data["spec_priority"] ? json.data["spec_priority"] : "None";
-                var phot_priority = json.data["phot_priority"] ? json.data["phot_priority"] : "None";
-                var offset_star_ra = json.data["offset_star_ra"] ? json.data["offset_star_ra"] : "None";
-                var offset_star_dec = json.data["offset_star_dec"] ? json.data["offset_star_dec"] : "None";
-                var offset_north = json.data["offset_north"] ? json.data["offset_north"] : "None";
-                var offset_east = json.data["offset_east"] ? json.data["offset_east"] : "None";
-                var comment = json.data["comment"] ? json.data["comment"] : "None";
+                var priority = (json.data["priority"] !== null && json.data["priority"] !== undefined) ? json.data["priority"] : "None";
+                var comment = json.data["comment"] ? json.data["comment"] : "";
 
                 var start_date = new Date(valid_start);
                 var end_date = new Date(valid_stop);
@@ -1916,28 +1917,17 @@
                     "<div class='box-header'>" +
                     "<div class='col-4'><h3 class='box-title'>Follow-up (id: " + followup_pk + ")</h3></div>" +
                     "<div class='col-4'><h3 class='box-title'>Valid: " + start_date_str + " - " + end_date_str + "</h3></div>" +
-                    "<div class='col-4'><h3 style='float:right;padding-right:10px' class='box-title'>Last Modified: " + modified_by + "</h3></div>" +
+                    "<div class='col-4'><h3 style='float:right;padding-right:10px' class='box-title'>Requestors: " + requestors + "</h3></div>" +
                     "<div class='box-tools float-right'><button type='button' class='btn btn-box-tool' data-widget='collapse'><i class='fa fa-minus'></i></button></div>" +
                     "</div><div class='box-body'>" +
                     "<table id='tbl_followup_" + followup_pk + "' class='table table-bordered table-striped'>" +
-                    "<thead><tr><th>Spec. Priority</th><th>Phot. Priority</th><th>Offset Star<br>RA</th><th>Offset Star<br>DEC</th><th>Offset North</th><th>Offset East</th><th>Attached Resource</th><th>Status</th><th>Comment</th><th>Action</th><th>Delete</th></tr></thead>" +
+                    "<thead><tr><th>Priority</th><th>Attached Resource</th><th>Status</th><th>Comment</th><th>Action</th><th>Delete</th></tr></thead>" +
                     "<tbody><tr>" +
-                    "<td>" + spec_priority + "</td><td>" + phot_priority + "</td>" +
-                    "<td>" + offset_star_ra + "</td><td>" + offset_star_dec + "</td>" +
-                    "<td>" + offset_north + "</td><td>" + offset_east + "</td>" +
+                    "<td>" + priority + "</td>" +
                     "<td>" + associated_resouces + "</td><td>" + status_name + "</td><td>" + comment + "</td>" +
                     "<td><a target='_blank' href='{% url 'admin:YSE_App_transientfollowup_changelist' %}" + followup_pk + "/change/'>Edit</a></td>" +
-                    "<td><a href='{% url 'delete_followup' -1 %}".replace('-1', followup_pk) + "'>Delete</a></td>" +
-                    "</tr></tbody></table><hr>" +
-                    "<h4 class='box-title'>Observation Tasks</h4>" +
-                    "<table id='tbl_obs_followup_" + followup_pk + "' class='table table-bordered table-striped'>" +
-                    "<thead><tr><th>ID</th><th>Obs.</th><th>Tel.</th><th>Inst.</th>" +
-                    "<th>Desired Obs.<br>Date (UTC)</th><th>Actual Obs.<br>Date (UTC)</th>" +
-                    "<th>Exp.<br>Time</th><th>Desc.</th><th># of<br>Exposures</th>" +
-                    "<th>Config. Name</th><th>Config. Detail</th><th>Status</th>" +
-                    "<th>Last<br>Modified By</th><th>Action</th></tr></thead>" +
-                    "<tbody><tr><td colspan='13'></td><td><b><a class='add_task' followup_id='" + followup_pk + "' href='#'>Add</a></b></td></tr>" +
-                    "</tbody></table><br></div></div></div>";
+                    "<td><a href='" + "{% url 'delete_followup' -1 %}".replace('-1', followup_pk) + "'>Delete</a></td>" +
+                    "</tr></tbody></table></div></div></div>";
 
                 $('#followup_container .text-muted').remove();
                 $('#followup_container .followupbox').each(function() {
@@ -1955,10 +1945,6 @@
                         if ($.fn.boxWidget) {
                             $newBox.boxWidget();
                         }
-                        $newRow.find('.add_task').on('click', function(event) {
-                            event.preventDefault();
-                            ToggleObservationTaskForm($(this).attr('followup_id'), true);
-                        });
                     });
                 });
             };

--- a/YSE_App/templates/YSE_App/transient_detail_followup_boxes.html
+++ b/YSE_App/templates/YSE_App/transient_detail_followup_boxes.html
@@ -13,7 +13,7 @@
                         <h3 class="box-title">Valid: {{ f.valid_start|date:"SHORT_DATE_FORMAT" }} - {{ f.valid_stop|date:"SHORT_DATE_FORMAT" }}</h3>
                     </div>
                     <div class="col-4">
-                        <h3 style="float:right;padding-right:10px" class="box-title">Last Modified: {{f.modified_by}}</h3>
+                        <h3 style="float:right;padding-right:10px" class="box-title">Requestors: {{f.requestors}}</h3>
                     </div>
                     <div class="box-tools float-right">
                         {% if forloop.counter <= 1 %}
@@ -27,12 +27,7 @@
                     <table id="tbl_followup_{{f.id}}" class="table table-bordered table-striped">
                         <thead>
                             <tr>
-                                <th>Spec. Priority</th>
-                                <th>Phot. Priority</th>
-                                <th>Offset Star<br>RA</th>
-                                <th>Offset Star<br>DEC</th>
-                                <th>Offset North</th>
-                                <th>Offset East</th>
+                                <th>Priority</th>
                                 <th>Attached Resource</th>
                                 <th>Status</th>
                                 <th>Comment</th>
@@ -42,12 +37,7 @@
                         </thead>
                         <tbody>
                             <tr>
-                                <td>{{ f.spec_priority }}</td>
-                                <td>{{ f.phot_priority }}</td>
-                                <td>{{ f.offset_star_ra }}</td>
-                                <td>{{ f.offset_star_dec }}</td>
-                                <td>{{ f.offset_north }}</td>
-                                <td>{{ f.offset_east }}</td>
+                                <td>{{ f.priority }}</td>
                                 <td>
                                     {% if f.too_resource %}{{ f.too_resource }}<br>{% endif %}
                                     {% if f.classical_resource %}{{ f.classical_resource }}<br>{% endif %}
@@ -57,58 +47,6 @@
                                 <td>{{ f.comment }}</td>
                                 <td><a target='_blank' href="{% url 'admin:YSE_App_transientfollowup_change' f.id %}">Edit</a></td>
                                 <td><a href="{% url 'delete_followup' f.id %}">Delete</a></td>
-                            </tr>
-                        </tbody>
-                    </table>
-                    <hr>
-                    <h4 class="box-title">Observation Tasks</h4>
-                    <table id="tbl_obs_followup_{{f.id}}" class="table table-bordered table-striped">
-                        <thead>
-                            <tr>
-                                <th>ID</th>
-                                <th>Obs.</th>
-                                <th>Tel.</th>
-                                <th>Inst.</th>
-                                <th>Desired Obs.<br>Date (UTC)</th>
-                                <th>Actual Obs.<br>Date (UTC)</th>
-                                <th>Exp.<br>Time</th>
-                                <th>Desc.</th>
-                                <th># of<br>Exp.</th>
-                                <th>Config. Name</th>
-                                <th>Config. Detail</th>
-                                <th>Status</th>
-                                <th>Last<br>Modified By</th>
-                                <th>Action</th>
-                            </tr>
-                        </thead>
-                        <tbody>
-                            {% for o in f.observation_set.all %}
-                                <tr>
-                                    <td>{{ o.id }}</td>
-                                    <td>{{ o.instrument_config.instrument.telescope.observatory.name }}</td>
-                                    <td>{{ o.instrument_config.instrument.telescope.name }}</td>
-                                    <td>{{ o.instrument_config.instrument.name }}</td>
-                                    <td>{{ o.desired_obs_date }}</td>
-                                    <td>{{ o.actual_obs_date }}</td>
-                                    <td>{{ o.exposure_time }}</td>
-                                    <td>{{ o.description }}</td>
-                                    <td>{{ o.number_of_exposures }}</td>
-                                    <td>{{ o.instrument_config.name }}</td>
-                                    <td>
-                                        <ul>
-                                            {% for c in o.instrument_config.configelement_set.all %}
-                                                <li>{{ c.name }}</li>
-                                            {% endfor %}
-                                        </ul>
-                                    </td>
-                                    <td>{{ o.status }}</td>
-                                    <td>{{ o.modified_by }}</td>
-                                    <td><a target='_blank' href="{% url 'admin:YSE_App_transientobservationtask_change' o.id %}">Edit</a></td>
-                                </tr>
-                            {% endfor %}
-                            <tr>
-                                <td colspan='13'></td>
-                                <td><b><a class="add_task" followup_id="{{f.id}}" href="#">Add</a></b></td>
                             </tr>
                         </tbody>
                     </table>

--- a/YSE_App/templates/YSE_App/transient_detail_followup_rest.html
+++ b/YSE_App/templates/YSE_App/transient_detail_followup_rest.html
@@ -3,10 +3,6 @@
         <input type="hidden" id="transient_pk" value="{{ transient.id }}"/>
         {% include "YSE_App/form_snippets/transient_followup_form.html" with form=transient_followup_form %}
     </div>
-    <div class="col-6">
-        <input type="hidden" id="followup_pk" />
-        {% include "YSE_App/form_snippets/transient_observation_task_form.html" with form=transient_observation_task_form %}
-    </div>
 </div>
 <div class="row">
     <div class="col-6">

--- a/YSE_App/templates/YSE_App/transient_summary_individual.html
+++ b/YSE_App/templates/YSE_App/transient_summary_individual.html
@@ -494,6 +494,7 @@
             var valid_start = json.data["valid_start"]
             var valid_stop = json.data["valid_stop"]
             var modified_by = json.data["modified_by"]
+            var requestors = json.data["requestors"] ? json.data["requestors"] : modified_by
 
             if (!followup_pk || !status_id || !status_name ||
               !valid_start || !valid_stop || !modified_by) {
@@ -505,12 +506,7 @@
             var classical_resource = json.data["classical_resource"]
             var queued_resource = json.data["queued_resource"]
 
-            var spec_priority = json.data["spec_priority"] ? json.data["spec_priority"] : "None"
-            var phot_priority = json.data["phot_priority"] ? json.data["phot_priority"] : "None"
-            var offset_star_ra = json.data["offset_star_ra"] ? json.data["offset_star_ra"] : "None"
-            var offset_star_dec = json.data["offset_star_dec"] ? json.data["offset_star_dec"] : "None"
-            var offset_north = json.data["offset_north"] ? json.data["offset_north"] : "None"
-            var offset_east = json.data["offset_east"] ? json.data["offset_east"] : "None"
+            var priority = (json.data["priority"] !== null && json.data["priority"] !== undefined) ? json.data["priority"] : "None"
 
             // Construct date strings
             var start_date = new Date(valid_start)
@@ -541,7 +537,7 @@
               "<h3 class='box-title'>Valid: " + start_date_str + " - " + end_date_str + "</h3>" + 
               "</div>" +
               "<div class='col-4'>" + 
-              "<h3 style='float:right;padding-right:10px' class='box-title'>Last Modified: " + modified_by + "</h3>" + 
+              "<h3 style='float:right;padding-right:10px' class='box-title'>Requestors: " + requestors + "</h3>" + 
               "</div>" +
               "<div class='box-tools float-right'>" +
               "<button type='button' class='btn btn-box-tool' data-widget='collapse'><i class='fa fa-minus'></i></button>" +
@@ -549,38 +545,14 @@
               "</div>" + 
               "<div class='box-body'>" + 
               "<table id='tbl_followup_" + followup_pk + "' class='table table-bordered table-striped'>" +
-              "<thead><tr><th>Spec. Priority</th><th>Phot. Priority</th><th>Offset Star<br>RA</th><th>Offset Star<br>DEC</th><th>Offset North</th><th>Offset East</th><th>Attached Resource</th><th>Status</th><th>Action</th></tr></thead>" + 
+              "<thead><tr><th>Priority</th><th>Attached Resource</th><th>Status</th><th>Comment</th><th>Action</th></tr></thead>" + 
               "<tbody><tr>" + 
-              "<td>" + spec_priority + "</td>" +
-              "<td>" + phot_priority + "</td>" +
-              "<td>" + offset_star_ra + "</td>" +
-              "<td>" + offset_star_dec + "</td>" +
-              "<td>" + offset_north + "</td>" +
-              "<td>" + offset_east + "</td>" +
+              "<td>" + priority + "</td>" +
               "<td>" + associated_resouces + "</td>" + 
-              "<td>" + status_name + "</td>" + 
+              "<td>" + status_name + "</td>" +
+              "<td>" + (json.data["comment"] ? json.data["comment"] : "") + "</td>" +
               "<td><a target='_blank' href='{% url 'admin:YSE_App_transientfollowup_changelist' %}" + followup_pk + "/change/'>Edit</a></td>" + 
-              "</tr></tbody></table><hr>" + 
-              "<h4 class='box-title'>Observation Tasks</h4>" + 
-              "<table id='tbl_obs_followup_" + followup_pk + "' class='table table-bordered table-striped'>" +
-              "<thead><tr>" +
-              "<th>ID</th>" + 
-              "<th>Obs.</th>" + 
-              "<th>Tel.</th>" +
-              "<th>Inst.</th>" +
-              "<th>Desired Obs.<br>Date (UTC)</th>" +
-              "<th>Actual Obs.<br>Date (UTC)</th>" +
-              "<th>Exp.<br>Time</th>" +
-              "<th>Desc.</th>" +
-              "<th># of<br>Exposures</th>" +
-              "<th>Config. Name</th>" +
-              "<th>Config. Detail</th>" +
-              "<th>Status</th>" +
-              "<th>Last<br>Modified By</th>" +
-              "<th>Action</th>" +
-              "</tr></thead>" + 
-              "<tbody><tr><td colspan='13'></td><td><b><a class='add_task' followup_id='" + followup_pk + "' href='#'>Add</a></b></td></tr>" + 
-              "</tbody></table><br></div></div></div>"
+              "</tr></tbody></table></div></div></div>"
 
               var container_collection = $("#followup_container > div")
               if (container_collection.length == 0) {
@@ -626,6 +598,7 @@
           }
         });
       };
+      window.add_transient_followup = add_transient_followup;
 
       // This function gets cookie with a given name
       function getCookie(name) {

--- a/YSE_App/tests/test_followup_requests.py
+++ b/YSE_App/tests/test_followup_requests.py
@@ -1,0 +1,251 @@
+"""Observing-request parent/child schema (issues #135–#138)."""
+
+from datetime import timedelta
+
+from django.core.exceptions import ValidationError
+from django.test import Client, TestCase
+from django.urls import reverse
+from django.utils import timezone
+
+from YSE_App.forms import TransientFollowupForm
+from YSE_App.models import (
+    FollowupStatus,
+    TransientFollowup,
+    TransientFollowupRequest,
+)
+from YSE_App.services.followup_requests import (
+    DEFAULT_PRIORITY,
+    create_or_attach_request,
+    effective_priority,
+    format_comments,
+    format_requestors,
+)
+from YSE_App.services.visibility import (
+    filter_transient_followups_for_user,
+    followup_visible_to_user,
+)
+from YSE_App.tests.fixtures_minimal import (
+    attach_synthetic_photometry,
+    create_minimal_transient,
+    create_test_user,
+)
+
+
+class FollowupRequestTests(TestCase):
+    def setUp(self):
+        self.user = create_test_user("fu_req_user")
+        self.user_b = create_test_user("fu_req_user_b", is_staff=False)
+        self.transient = create_minimal_transient(self.user, name="fureq01")
+        self.requested, _ = FollowupStatus.objects.get_or_create(
+            name="Requested",
+            defaults={"created_by": self.user, "modified_by": self.user},
+        )
+        self.successful, _ = FollowupStatus.objects.get_or_create(
+            name="Successful",
+            defaults={"created_by": self.user, "modified_by": self.user},
+        )
+        self.failed, _ = FollowupStatus.objects.get_or_create(
+            name="Failed",
+            defaults={"created_by": self.user, "modified_by": self.user},
+        )
+        self.now = timezone.now()
+        self.stop = self.now + timedelta(days=7)
+
+    def _create(self, user, *, status=None, priority=DEFAULT_PRIORITY, comment="", **kwargs):
+        return create_or_attach_request(
+            user,
+            self.transient,
+            status=status or self.requested,
+            valid_start=self.now,
+            valid_stop=self.stop,
+            priority=priority,
+            comment=comment,
+            **kwargs,
+        )
+
+    def test_first_submit_creates_parent_and_child(self):
+        parent, child, created = self._create(self.user, comment="first look")
+        self.assertTrue(created)
+        self.assertEqual(TransientFollowup.objects.count(), 1)
+        self.assertEqual(TransientFollowupRequest.objects.count(), 1)
+        self.assertEqual(child.requestor, self.user)
+        self.assertEqual(child.priority, DEFAULT_PRIORITY)
+        self.assertEqual(child.comment, "first look")
+        self.assertEqual(parent.requested_by, self.user)
+        self.assertEqual(parent.status, self.requested)
+        self.assertEqual(parent.priority, DEFAULT_PRIORITY)
+
+    def test_second_submit_same_resource_attaches(self):
+        parent1, _, created1 = self._create(self.user, comment="one")
+        parent2, child2, created2 = self._create(self.user_b, priority=2.0, comment="two")
+        self.assertTrue(created1)
+        self.assertFalse(created2)
+        self.assertEqual(parent1.id, parent2.id)
+        self.assertEqual(TransientFollowup.objects.count(), 1)
+        self.assertEqual(parent2.requests.count(), 2)
+        self.assertEqual(child2.requestor, self.user_b)
+
+    def test_attach_does_not_change_parent_status(self):
+        parent, _, _ = self._create(self.user)
+        in_process, _ = FollowupStatus.objects.get_or_create(
+            name="InProcess",
+            defaults={"created_by": self.user, "modified_by": self.user},
+        )
+        parent.status = in_process
+        parent.save(update_fields=["status"])
+        _, _, created = self._create(self.user_b, status=self.requested)
+        parent.refresh_from_db()
+        self.assertFalse(created)
+        self.assertEqual(parent.status, in_process)
+
+    def test_terminal_parent_gets_new_parent(self):
+        parent, _, _ = self._create(self.user)
+        parent.status = self.successful
+        parent.save(update_fields=["status"])
+        new_parent, _, created = self._create(self.user, comment="again")
+        self.assertTrue(created)
+        self.assertNotEqual(parent.id, new_parent.id)
+        self.assertEqual(TransientFollowup.objects.count(), 2)
+
+    def test_same_user_new_child_uses_latest_priority(self):
+        parent, _, _ = self._create(self.user, priority=2.0)
+        _, _, created = self._create(self.user, priority=4.0)
+        self.assertFalse(created)
+        parent.refresh_from_db()
+        self.assertEqual(parent.requests.count(), 2)
+        self.assertEqual(effective_priority(parent), 4.0)
+        self.assertEqual(parent.priority, 4.0)
+
+    def test_effective_priority_is_min_of_each_users_latest(self):
+        parent, _, _ = self._create(self.user, priority=2.0)
+        self._create(self.user, priority=4.0)
+        self._create(self.user_b, priority=3.0)
+        parent.refresh_from_db()
+        self.assertEqual(effective_priority(parent), 3.0)
+        self.assertEqual(parent.priority, 3.0)
+
+    def test_comments_accumulate_with_requestor_labels(self):
+        parent, _, _ = self._create(self.user, comment="need spectrum")
+        self._create(self.user_b, comment="ToO tonight")
+        parent.refresh_from_db()
+        text = format_comments(parent)
+        self.assertIn("fu_req_user: need spectrum", text)
+        self.assertIn("fu_req_user_b: ToO tonight", text)
+        self.assertNotRegex(text, r"\d{4}-\d{2}-\d{2}")
+        requestors = format_requestors(parent)
+        self.assertIn("fu_req_user", requestors)
+        self.assertIn("fu_req_user_b", requestors)
+
+    def test_priority_out_of_range_rejected(self):
+        with self.assertRaises(ValidationError):
+            self._create(self.user, priority=0.5)
+        with self.assertRaises(ValidationError):
+            self._create(self.user, priority=5.1)
+
+    def test_form_default_priority_is_4(self):
+        form = TransientFollowupForm()
+        self.assertEqual(form.fields["priority"].initial, 4.0)
+
+    def test_form_rejects_priority_outside_range(self):
+        data = {
+            "status": self.requested.id,
+            "valid_start": self.now,
+            "valid_stop": self.stop,
+            "priority": 0.0,
+            "transient": self.transient.id,
+        }
+        form = TransientFollowupForm(data)
+        self.assertFalse(form.is_valid())
+        self.assertIn("priority", form.errors)
+
+        data["priority"] = 6.0
+        form = TransientFollowupForm(data)
+        self.assertFalse(form.is_valid())
+        self.assertIn("priority", form.errors)
+
+    def test_non_ajax_post_creates_request_and_redirects(self):
+        client = Client()
+        client.force_login(self.user)
+        response = client.post(
+            reverse("add_transient_followup"),
+            {
+                "status": self.requested.id,
+                "valid_start": self.now.strftime("%Y-%m-%d %H:%M:%S"),
+                "valid_stop": self.stop.strftime("%Y-%m-%d %H:%M:%S"),
+                "priority": 4.0,
+                "comment": "native post",
+                "transient": self.transient.id,
+            },
+        )
+        self.assertEqual(response.status_code, 302)
+        self.assertIn(self.transient.slug, response.url)
+        self.assertEqual(TransientFollowup.objects.count(), 1)
+        self.assertEqual(TransientFollowupRequest.objects.count(), 1)
+
+    def test_ajax_form_attaches_second_request(self):
+        client = Client()
+        client.force_login(self.user)
+        payload = {
+            "status": self.requested.id,
+            "valid_start": self.now.strftime("%Y-%m-%d %H:%M:%S"),
+            "valid_stop": self.stop.strftime("%Y-%m-%d %H:%M:%S"),
+            "priority": 4.0,
+            "comment": "ajax one",
+            "transient": self.transient.id,
+        }
+        response = client.post(
+            reverse("add_transient_followup"),
+            payload,
+            HTTP_X_REQUESTED_WITH="XMLHttpRequest",
+        )
+        self.assertEqual(response.status_code, 200)
+        first_id = response.json()["data"]["id"]
+        self.assertFalse(response.json()["data"]["attached"])
+
+        client_b = Client()
+        client_b.force_login(self.user_b)
+        payload["priority"] = 2.0
+        payload["comment"] = "ajax two"
+        response = client_b.post(
+            reverse("add_transient_followup"),
+            payload,
+            HTTP_X_REQUESTED_WITH="XMLHttpRequest",
+        )
+        self.assertEqual(response.status_code, 200)
+        data = response.json()["data"]
+        self.assertTrue(data["attached"])
+        self.assertEqual(data["id"], first_id)
+        self.assertEqual(data["priority"], 2.0)
+        self.assertIn("fu_req_user", data["requestors"])
+        self.assertIn("fu_req_user_b", data["requestors"])
+        self.assertIn("ajax one", data["comment"])
+        self.assertIn("ajax two", data["comment"])
+        self.assertEqual(TransientFollowup.objects.count(), 1)
+        self.assertEqual(TransientFollowupRequest.objects.count(), 2)
+
+    def test_child_requestor_sees_private_parent(self):
+        attach_synthetic_photometry(self.user, self.transient, n_points=2)
+        parent, _, _ = self._create(self.user, comment="private")
+        parent.is_public = False
+        parent.save(update_fields=["is_public"])
+        self._create(self.user_b, priority=3.0, comment="joining")
+        parent.refresh_from_db()
+        self.assertTrue(followup_visible_to_user(self.user_b, parent))
+        qs = filter_transient_followups_for_user(
+            TransientFollowup.objects.filter(transient=self.transient),
+            self.user_b,
+        )
+        self.assertEqual(qs.count(), 1)
+
+    def test_automated_spectrum_style_default_priority_creates_child(self):
+        parent, child, created = create_or_attach_request(
+            self.user,
+            self.transient,
+            status=self.requested,
+            valid_start=self.now,
+            valid_stop=self.stop,
+            priority=DEFAULT_PRIORITY,
+        )
+        self.assertTrue(created)
+        self.assertEqual(child.priority, 4.0)
+        self.assertEqual(parent.priority, 4.0)

--- a/YSE_App/tests/test_group_visibility.py
+++ b/YSE_App/tests/test_group_visibility.py
@@ -1,10 +1,15 @@
 """Group-based visibility for comments and shared helpers (issue #102)."""
 
+from datetime import timedelta
+
 from django.contrib.auth.models import Group, User
 from django.test import Client, TestCase
 from django.urls import reverse
-from YSE_App.models import Log, TransientFollowup, TransientPhotometry
+from django.utils import timezone
+
+from YSE_App.models import FollowupStatus, Log, TransientFollowup, TransientPhotometry
 from YSE_App.services.comments import create_transient_comment, transient_comment_queryset
+from YSE_App.services.followup_requests import create_or_attach_request
 from YSE_App.services.visibility import (
     filter_transient_comments_for_user,
     filter_transient_followups_for_user,
@@ -133,10 +138,6 @@ class GroupVisibilityTests(TestCase):
         self.assertEqual(response.status_code, 403)
 
     def _create_followup(self, user, *, is_public=True, groups=None):
-        from YSE_App.models import FollowupStatus
-        from django.utils import timezone
-        from datetime import timedelta
-
         status, _ = FollowupStatus.objects.get_or_create(
             name="sec-test-requested",
             defaults={
@@ -194,3 +195,31 @@ class GroupVisibilityTests(TestCase):
         payload = response.json()
         results = payload.get("results", payload)
         self.assertEqual(len(results), 0)
+
+    def test_private_followup_visible_to_child_requestor(self):
+        self.user_b.groups.add(self.group_a)
+        status, _ = FollowupStatus.objects.get_or_create(
+            name="sec-test-requested",
+            defaults={"created_by": self.user_a, "modified_by": self.user_a},
+        )
+        now = timezone.now()
+        parent, _, _ = create_or_attach_request(
+            self.user_a,
+            self.transient,
+            status=status,
+            valid_start=now,
+            valid_stop=now + timedelta(days=7),
+            comment="owner",
+        )
+        parent.is_public = False
+        parent.save(update_fields=["is_public"])
+        create_or_attach_request(
+            self.user_b,
+            self.transient,
+            status=status,
+            valid_start=now,
+            valid_stop=now + timedelta(days=7),
+            comment="other user",
+        )
+        parent.refresh_from_db()
+        self.assertTrue(followup_visible_to_user(self.user_b, parent))

--- a/YSE_App/views.py
+++ b/YSE_App/views.py
@@ -1213,6 +1213,7 @@ def _transient_detail_defer_enabled():
 
 
 def _load_transient_followups(transient_id, user):
+    from YSE_App.services.followup_requests import format_comments, format_requestors
     from YSE_App.services.visibility import filter_transient_followups_for_user
 
     followups = list(
@@ -1233,20 +1234,14 @@ def _load_transient_followups(transient_id, user):
                     queryset=TransientObservationTask.objects.select_related(
                         'instrument_config', 'status'
                     ),
-                )
+                ),
+                'requests__requestor',
             ),
             user,
         )
     )
     if not followups:
         return followups
-    followup_ids = [f.id for f in followups]
-    comments_by_followup = {}
-    for log_row in Log.objects.filter(
-        transient_followup_id__in=followup_ids
-    ).values('transient_followup_id', 'comment'):
-        fid = log_row['transient_followup_id']
-        comments_by_followup.setdefault(fid, []).append(log_row['comment'])
 
     for followup in followups:
         followup.observation_set = list(followup.transientobservationtask_set.all())
@@ -1256,9 +1251,8 @@ def _load_transient_followups(transient_id, user):
             followup.resource = followup.too_resource
         elif followup.queued_resource:
             followup.resource = followup.queued_resource
-        comment_list = comments_by_followup.get(followup.id, [])
-        if comment_list:
-            followup.comment = '; '.join(comment_list)
+        followup.requestors = format_requestors(followup)
+        followup.comment = format_comments(followup)
     return followups
 
 

--- a/docs/security-groups.md
+++ b/docs/security-groups.md
@@ -8,7 +8,7 @@ YSE uses Django **collaboration groups** (`auth.Group`) on photometry, spectra, 
 - **Every user** is a member of the `Public` collaboration group (signal on user create + `ensure_users_in_public_group` for backfill).
 - **New transient comments**: private by default (`Log.is_public=False` with `Log.groups` set to shared collaboration groups). Opt-in `is_public=True` for all collaborators who can open the transient.
 - **Legacy comments** (before migration `0005_log_visibility`): `is_public=True`, no groups — unchanged visibility.
-- **Follow-up requests** (`TransientFollowup`): audience is set via collaboration groups at create time (`is_public=False` on new rows). Legacy rows with `is_public=True` and no groups remain visible to Public group members who can also see the linked observing resource. Restricted follow-ups require group membership **and** visibility of the linked classical/ToO/queued resource.
+- **Follow-up requests** (`TransientFollowup`): audience is set via collaboration groups at create time (`is_public=False` on new rows). Legacy rows with `is_public=True` and no groups remain visible to Public group members who can also see the linked observing resource. Restricted follow-ups require group membership **and** visibility of the linked classical/ToO/queued resource. `requested_by` is the first requestor; any `TransientFollowupRequest.requestor` can also see a private parent.
 
 ## Code
 


### PR DESCRIPTION
## Summary
- Add `TransientFollowupRequest` children (float priority 1.0–5.0, default 4.0) with attach-or-create on existing parent for same transient+resource
- Display: consolidated requestors, min-of-latest priority, labeled comments (no timestamps); hide offset columns and observation-task UI
- Preserve experimental audience picker / AdminLTE submit path; child requestors can see private parents
- Observing-night toolbar padding + compact status dropdown CSS
- Migration `0008_followup_requests` (depends on `0007_resource_creator_only`)

Fixes #66. Tracks #135 / #136 / #137 / #138.

## Test plan
- [ ] `manage.py migrate` on experimental
- [ ] `manage.py test YSE_App.tests.test_followup_requests YSE_App.tests.test_group_visibility --keepdb`
- [ ] Submit follow-up on transient detail: no full-page reload; row appears with requestors/priority/comment
- [ ] Second user attach: same parent, updated requestors + priority
- [ ] Observing night: compact status dropdowns; Download/Search vertical gap aligned


Made with [Cursor](https://cursor.com)