### PR TITLE
ci: sudo for develop Ziggy deploy (unblock yse_test)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -34,12 +34,16 @@ jobs:
               echo "branch=experimental" >> "$GITHUB_OUTPUT"
               # Matches yse-experimental.conf WSGIDaemonProcess python-home
               echo "python=/data/yse_pz/YSE_PZ_experimental/venv/bin/python" >> "$GITHUB_OUTPUT"
+              # Project venv is writable by the runner
+              echo "elevate=" >> "$GITHUB_OUTPUT"
               ;;
             develop)
               echo "dir=/data/yse_pz/YSE_PZ_test" >> "$GITHUB_OUTPUT"
               echo "branch=develop" >> "$GITHUB_OUTPUT"
               # Matches yse-test.conf WSGIDaemonProcess python-home
               echo "python=/data/yse_pz/yse_test_virtual/bin/python" >> "$GITHUB_OUTPUT"
+              # Shared env is root-owned; runner needs sudo (same as apache restart)
+              echo "elevate=sudo -H" >> "$GITHUB_OUTPUT"
               ;;
             *)
               echo "Unsupported deploy branch: $BRANCH" >&2
@@ -52,18 +56,22 @@ jobs:
         run: |
           cd "${{ steps.target.outputs.dir }}"
           PYTHON="${{ steps.target.outputs.python }}"
+          # shellcheck disable=SC2086
+          ELEVATE="${{ steps.target.outputs.elevate }}"
 
           git fetch origin
           git reset --hard "origin/${{ steps.target.outputs.branch }}"
 
-          "$PYTHON" -m pip install wheel
-          "$PYTHON" -m pip install --no-build-isolation "extinction==0.4.2"
-          "$PYTHON" -m pip install "sncosmo==2.8.0" "urllib3<1.27" "django>=3.2,<4.0"
-          "$PYTHON" -m pip install --use-deprecated=legacy-resolver -r requirements.txt
+          run_py() { $ELEVATE "$PYTHON" "$@"; }
 
-          "$PYTHON" manage.py migrate --noinput --skip-checks
+          run_py -m pip install wheel
+          run_py -m pip install --no-build-isolation "extinction==0.4.2"
+          run_py -m pip install "sncosmo==2.8.0" "urllib3<1.27" "django>=3.2,<4.0"
+          run_py -m pip install --use-deprecated=legacy-resolver -r requirements.txt
+
+          run_py manage.py migrate --noinput --skip-checks
 
           # Apache serves /static/ from STATIC_ROOT; chrome/vendor CSS lands here.
-          "$PYTHON" manage.py collectstatic --noinput
+          run_py manage.py collectstatic --noinput
 
           sudo systemctl restart apache2


### PR DESCRIPTION
## Summary
Same fix as the experimental PR: elevate pip/migrate/collectstatic with `sudo -H` when deploying **develop** → `YSE_PZ_test` / `yse_test_virtual`.

Merge this (or promote experimental after that PR lands) so the next develop deploy can finish.

Fixes #153

## Test plan
- [ ] Merge → Deploy Stack for `develop` succeeds
- [ ] `/yse_test/` hard-refresh shows chrome + audience UI


Made with [Cursor](https://cursor.com)